### PR TITLE
BE - 스프링 시큐리티 설정, jwt 재발급 및 검증 로직 수정

### DIFF
--- a/src/main/java/com/zerobase/foodlier/common/redis/domain/model/RefreshToken.java
+++ b/src/main/java/com/zerobase/foodlier/common/redis/domain/model/RefreshToken.java
@@ -5,10 +5,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 
-import javax.persistence.Id;
+
 
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/zerobase/foodlier/common/redis/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/zerobase/foodlier/common/redis/repository/RefreshTokenRepository.java
@@ -3,11 +3,6 @@ package com.zerobase.foodlier.common.redis.repository;
 import com.zerobase.foodlier.common.redis.domain.model.RefreshToken;
 import org.springframework.data.repository.CrudRepository;
 
-import java.util.Optional;
-
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
-
-    boolean existsByEmail(String email);
-    Optional<RefreshToken> findByEmail(String email);
 
 }

--- a/src/main/java/com/zerobase/foodlier/common/redis/service/RefreshTokenService.java
+++ b/src/main/java/com/zerobase/foodlier/common/redis/service/RefreshTokenService.java
@@ -5,9 +5,12 @@ import com.zerobase.foodlier.common.redis.dto.RefreshTokenDto;
 
 public interface RefreshTokenService {
 
-    void validRefreshToken(String email);
+    boolean isRefreshTokenExisted(String email);
+
     void save(RefreshTokenDto refreshTokenDto);
-    void delete(RefreshToken refreshToken);
+
+    void delete(String email);
+
     RefreshToken findRefreshToken(String email);
 
 }

--- a/src/main/java/com/zerobase/foodlier/common/redis/service/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/zerobase/foodlier/common/redis/service/RefreshTokenServiceImpl.java
@@ -19,14 +19,12 @@ public class RefreshTokenServiceImpl implements RefreshTokenService{
     private final RefreshTokenRepository refreshTokenRepository;
 
     public RefreshToken findRefreshToken(String email){
-        return refreshTokenRepository.findByEmail(email)
+        return refreshTokenRepository.findById(email)
                 .orElseThrow(()->new RefreshTokenException(REFRESH_NOT_FOUND));
     }
 
-    public void validRefreshToken(String email){
-        if(!refreshTokenRepository.existsByEmail(email)){
-            throw new RefreshTokenException(REFRESH_NOT_FOUND);
-        }
+    public boolean isRefreshTokenExisted(String email) {
+        return refreshTokenRepository.existsById(email);
     }
 
     public void save(RefreshTokenDto refreshTokenDto){
@@ -37,7 +35,9 @@ public class RefreshTokenServiceImpl implements RefreshTokenService{
                 .build());
     }
 
-    public void delete(RefreshToken refreshToken){
-        refreshTokenRepository.delete(refreshToken);
+    public void delete(String email){
+        if(refreshTokenRepository.existsById(email)){
+            refreshTokenRepository.deleteById(email);
+        }
     }
 }

--- a/src/main/java/com/zerobase/foodlier/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/zerobase/foodlier/common/security/config/SecurityConfig.java
@@ -26,15 +26,14 @@ public class SecurityConfig {
 
         httpSecurity.csrf().disable();
         httpSecurity.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
-        httpSecurity.authorizeHttpRequests()
-                .antMatchers("/**/auth/signup", "/**/auth/login", "/**/authKey/send", "/**/auth/verify", "/**/auth/signin").permitAll()
-                .anyRequest().authenticated()
-                .and()
+        httpSecurity
                 .addFilterBefore(
                         this.jwtAuthenticationFilter,
                         UsernamePasswordAuthenticationFilter.class
-                ).addFilterBefore(this.jwtExceptionFilter, JwtAuthenticationFilter.class);
-        httpSecurity.authorizeHttpRequests().anyRequest().authenticated();
+                )
+                .addFilterBefore(this.jwtExceptionFilter, JwtAuthenticationFilter.class)
+                .authorizeHttpRequests()
+                .anyRequest().authenticated();
         return httpSecurity.build();
 
     }

--- a/src/main/java/com/zerobase/foodlier/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zerobase/foodlier/common/security/filter/JwtAuthenticationFilter.java
@@ -21,7 +21,7 @@ import static com.zerobase.foodlier.common.security.exception.JwtErrorCode.*;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
-    
+
 
     private final JwtTokenProvider tokenProvider;
 
@@ -42,7 +42,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (this.tokenProvider.isTokenExpired(accessToken) && this.tokenProvider.existRefreshToken(accessToken)) {
             String reissuedAccessToken = this.tokenProvider.reissue(accessToken);
             response.setHeader(TOKEN_HEADER, reissuedAccessToken);
-            throw new JwtException(REFRESH_TOKEN_NOT_FOUND);
+            throw new JwtException(ACCESS_TOKEN_EXPIRED);
         }
 
         if (!this.tokenProvider.isTokenExpired(accessToken)) {

--- a/src/main/java/com/zerobase/foodlier/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zerobase/foodlier/common/security/filter/JwtAuthenticationFilter.java
@@ -21,8 +21,7 @@ import static com.zerobase.foodlier.common.security.exception.JwtErrorCode.*;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
-
-    private static final String EMPTY_REFRESH_TOKEN = "";
+    
 
     private final JwtTokenProvider tokenProvider;
 

--- a/src/main/java/com/zerobase/foodlier/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zerobase/foodlier/common/security/filter/JwtAuthenticationFilter.java
@@ -4,9 +4,7 @@ import com.zerobase.foodlier.common.security.exception.JwtException;
 import com.zerobase.foodlier.common.security.provider.JwtTokenProvider;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -18,11 +16,9 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 import static com.zerobase.foodlier.common.security.constants.AuthorizationConstants.*;
-import static com.zerobase.foodlier.common.security.exception.JwtErrorCode.EMPTY_TOKEN;
-import static com.zerobase.foodlier.common.security.exception.JwtErrorCode.MALFORMED_JWT_REQUEST;
+import static com.zerobase.foodlier.common.security.exception.JwtErrorCode.*;
 
 
-@Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
@@ -38,16 +34,25 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
 
 
+        String accessToken = this.resolveTokenFromRequest(request);
 
-        String accessToken = this.resolveTokenFromRequest(request, TOKEN_HEADER);
-        String refreshToken = this.extractRefreshToken(request);
-        this.tokenProvider.validateToken(accessToken, refreshToken);
+        if (this.tokenProvider.isTokenExpired(accessToken) && !this.tokenProvider.existRefreshToken(accessToken)) {
+            throw new JwtException(ALL_TOKEN_EXPIRED);
+        }
 
-        filterChain.doFilter(request, response);
+        if (this.tokenProvider.isTokenExpired(accessToken) && this.tokenProvider.existRefreshToken(accessToken)) {
+            String reissuedAccessToken = this.tokenProvider.reissue(accessToken);
+            response.setHeader(TOKEN_HEADER, reissuedAccessToken);
+            throw new JwtException(REFRESH_TOKEN_NOT_FOUND);
+        }
+
+        if (!this.tokenProvider.isTokenExpired(accessToken)) {
+            setSecurityContext(accessToken);
+        }
     }
 
-    private String resolveTokenFromRequest(@NonNull HttpServletRequest request, String tokenHeader) {
-        String token = request.getHeader(tokenHeader);
+    private String resolveTokenFromRequest(@NonNull HttpServletRequest request) {
+        String token = request.getHeader(TOKEN_HEADER);
 
         if (ObjectUtils.isEmpty(token)) {
             throw new JwtException(EMPTY_TOKEN);
@@ -60,11 +65,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return token.substring(TOKEN_PREFIX.length());
     }
 
-    public String extractRefreshToken(HttpServletRequest request){
-        if (StringUtils.hasText(request.getHeader(REFRESH_HEADER))) {
-            return this.resolveTokenFromRequest(request, REFRESH_HEADER);
-        }
-        return EMPTY_REFRESH_TOKEN;
+    private void setSecurityContext(String accessToken) {
+        SecurityContextHolder.getContext().setAuthentication(this.tokenProvider.getAuthentication(accessToken));
     }
-
 }

--- a/src/main/java/com/zerobase/foodlier/common/security/provider/JwtTokenProvider.java
+++ b/src/main/java/com/zerobase/foodlier/common/security/provider/JwtTokenProvider.java
@@ -1,22 +1,25 @@
 package com.zerobase.foodlier.common.security.provider;
 
 
-import com.zerobase.foodlier.common.redis.domain.model.RefreshToken;
 import com.zerobase.foodlier.common.redis.dto.RefreshTokenDto;
 import com.zerobase.foodlier.common.redis.service.RefreshTokenService;
 import com.zerobase.foodlier.common.security.exception.JwtException;
 import com.zerobase.foodlier.common.security.provider.constants.TokenExpiredConstant;
 import com.zerobase.foodlier.common.security.provider.dto.CreateTokenDto;
+import com.zerobase.foodlier.common.security.provider.dto.MemberAuthDto;
 import com.zerobase.foodlier.common.security.provider.dto.TokenDto;
-import com.zerobase.foodlier.module.member.member.domain.model.Member;
 import io.jsonwebtoken.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.zerobase.foodlier.common.security.exception.JwtErrorCode.*;
 
@@ -33,33 +36,33 @@ public class JwtTokenProvider {
     @Value("${spring.jwt.secret}")
     private String accessSecretKey;
 
-    public String createAccessToken(Member member) {
+    public String createAccessToken(MemberAuthDto memberAuthDto) {
         return setToken(CreateTokenDto.builder()
-                .id(member.getId())
-                .email(member.getEmail())
-                .roles(member.getRoles())
+                .id(memberAuthDto.getId())
+                .email(memberAuthDto.getEmail())
+                .roles(memberAuthDto.getRoles())
                 .keyRoles(KEY_ROLES)
                 .tokenExpiredTime(tokenExpiredConstant.getAccessTokenExpiredTime())
                 .secretKey(accessSecretKey)
                 .build());
     }
 
-    public String createRefreshToken(Member member) {
+    public String createRefreshToken(MemberAuthDto memberAuthDto) {
         return setToken(CreateTokenDto.builder()
-                .id(member.getId())
-                .email(member.getEmail())
+                .id(memberAuthDto.getId())
+                .email(memberAuthDto.getEmail())
                 .tokenExpiredTime(tokenExpiredConstant.getRefreshTokenExpiredTime())
                 .secretKey(accessSecretKey)
                 .build());
     }
 
-    public TokenDto createToken(Member member) {
+    public TokenDto createToken(MemberAuthDto memberAuthDto) {
 
-        String accessToken = createAccessToken(member);
-        String refreshToken = createRefreshToken(member);
+        String accessToken = createAccessToken(memberAuthDto);
+        String refreshToken = createRefreshToken(memberAuthDto);
 
         refreshTokenService.save(RefreshTokenDto.builder()
-                .userEmail(member.getEmail())
+                .userEmail(memberAuthDto.getEmail())
                 .refreshToken(refreshToken)
                 .timeToLive(tokenExpiredConstant.getRefreshTokenExpiredTime())
                 .build());
@@ -67,25 +70,31 @@ public class JwtTokenProvider {
         return new TokenDto(accessToken, refreshToken);
     }
 
-
-    public TokenDto reissueByRefreshToken(Member member, TokenDto tokenDto) {
-        Claims accessTokenClaims = this.parseClaims(tokenDto.getAccessToken());
-
-        if (!isTokenExpired(accessTokenClaims)) {
-            return tokenDto;
+    public String reissue(String accessToken) {
+        Claims accessTokenClaims = this.parseClaims(accessToken);
+        String userEmail = accessTokenClaims.getSubject();
+        Long userId = Long.parseLong(accessTokenClaims.getId());
+        List<String> roles = getRoles(accessToken);
+        if (!refreshTokenService.isRefreshTokenExisted(userEmail)) {
+            throw new JwtException(REFRESH_TOKEN_NOT_FOUND);
         }
-        refreshTokenService.validRefreshToken(tokenDto.getRefreshToken());
-        RefreshToken refreshToken = refreshTokenService.findRefreshToken(member.getEmail());
-        refreshTokenService.delete(refreshToken);
+        return this.createAccessToken(MemberAuthDto.builder()
+                                                    .id(userId)
+                                                    .email(userEmail)
+                                                    .roles(roles)
+                                                    .build());
+    }
 
-        return this.createToken(member);
+    private List<String> getRoles(String token) {
+        Claims claims = parseClaims(token);
+        List<?> list = claims.get(KEY_ROLES, List.class);
+        return list.stream().map(String::valueOf).collect(Collectors.toList());
     }
 
     public void deleteRefreshToken(String email) {
-        RefreshToken refreshToken = refreshTokenService.findRefreshToken(email);
-        refreshTokenService.delete(refreshToken);
+        refreshTokenService.delete(email);
     }
-
+    
     public String setToken(CreateTokenDto createTokenDto) {
         Claims claims = Jwts.claims().setSubject(createTokenDto.getEmail());
         claims.setId(String.valueOf(createTokenDto.getId()));
@@ -103,30 +112,27 @@ public class JwtTokenProvider {
                 .compact();
     }
 
+    public Authentication getAuthentication(String token) {
 
-    public void validateToken(String accessToken, String refreshToken) {
-        if (!StringUtils.hasText(accessToken)) {
-            throw new JwtException(MALFORMED_JWT_REQUEST);
-        }
+        Claims claims = this.parseClaims(token);
+        String userEmail = claims.getSubject();
+        Long id = Long.parseLong(claims.getId());
+        List<String> roles = this.getRoles(token);
+
+        return new UsernamePasswordAuthenticationToken();
+
+    }
+
+    public boolean existRefreshToken(String accessToken) {
+
         Claims claims = this.parseClaims(accessToken);
-        if (isTokenExpired(claims)) {
-            if (!this.existRefreshToken(refreshToken)) {
-                throw new JwtException(ACCESS_TOKEN_EXPIRED);
-            }
+        String userEmail = claims.getSubject();
 
-            Claims refreshClaims = this.parseClaims(refreshToken);
-
-            if (this.isTokenExpired(refreshClaims)) {
-                throw new JwtException(ALL_TOKEN_EXPIRED);
-            }
-        }
+        return refreshTokenService.isRefreshTokenExisted(userEmail);
     }
 
-    private boolean existRefreshToken(String refreshToken) {
-        return StringUtils.hasText(refreshToken);
-    }
-
-    private boolean isTokenExpired(Claims claims) {
+    public boolean isTokenExpired(String token) {
+        Claims claims = this.parseClaims(token);
         return claims.getExpiration().before(new Date());
     }
 

--- a/src/main/java/com/zerobase/foodlier/common/security/provider/dto/MemberAuthDto.java
+++ b/src/main/java/com/zerobase/foodlier/common/security/provider/dto/MemberAuthDto.java
@@ -1,0 +1,19 @@
+package com.zerobase.foodlier.common.security.provider.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberAuthDto {
+
+    private Long id;
+    private String email;
+    private List<String> roles;
+}


### PR DESCRIPTION
## Summary
- 스프링 시큐리티 설정 변경
-  jwt 재발급 로직 수정
-  jwt 검증 로직 수정
 
## Describe your changes

### 스프링 시큐리티 설정 변경(SecurityConfig)
swagger에서 jwt 인증 방식을 사용할 수 있도록 url 별 인증 설정 수정

### jwt 재발급 로직 수정(JwtAuthenticationFilter, JwtProvider)

#### 기존
- 접근 토큰이 만료되었을 때, 재발급 토큰이 유효하다면 재발급 요청 메세지 전송
- 클라이언트에서 재발급 요청
- 새로운 접근 토큰을 발급

#### 변경 후
- 접근 토큰 만료 시, 재발급 토큰이 유효할 때 새로운 접근 토큰을 재발급하고 접근 토큰 만료 메세지와 함께 새로운 접근 토큰을 response header에 담아서 메세지와 함께 전송
- 클라이언트에서 새로운 접근 토큰을 이용하여 원하는 요청을 재요청

### jwt 검증 로직 수정(JwtAuthenticationFilter, JwtProvider)
- 접근 토큰을 중심으로 검증
- 총 3가지 경우에 대해서 검증
    - 접근 토큰 유효
        - 정상
    - 접근 토큰 만료 & 재발급 토큰 유효
        - 접근 토큰 재발급
    - 접근 토큰 만료 & 재발급 토큰 만료
        - 재 로그인 필요
    
## Issue number and link
#15 