### PR TITLE
BE - jwt 발급 로직 변경 및 jwt 발급 및 검증 로직 테스트

### DIFF
--- a/src/main/java/com/zerobase/foodlier/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zerobase/foodlier/common/security/filter/JwtAuthenticationFilter.java
@@ -13,6 +13,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Date;
 
 import static com.zerobase.foodlier.common.security.constants.AuthorizationConstants.TOKEN_HEADER;
 import static com.zerobase.foodlier.common.security.constants.AuthorizationConstants.TOKEN_PREFIX;
@@ -42,7 +43,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (this.tokenProvider.isTokenExpired(accessToken)
                 && this.tokenProvider.existRefreshToken(accessToken)) {
-            String reissuedAccessToken = this.tokenProvider.reissue(accessToken);
+            String reissuedAccessToken = this.tokenProvider.reissue(accessToken, new Date());
             response.setHeader(TOKEN_HEADER, reissuedAccessToken);
             throw new JwtException(ACCESS_TOKEN_EXPIRED);
         }

--- a/src/main/java/com/zerobase/foodlier/common/security/provider/JwtTokenProvider.java
+++ b/src/main/java/com/zerobase/foodlier/common/security/provider/JwtTokenProvider.java
@@ -87,7 +87,7 @@ public class JwtTokenProvider {
                 .refreshToken(refreshToken)
                 .timeToLive(tokenExpiredConstant.getRefreshTokenExpiredMinute())
                 .build());
-        
+
         return new TokenDto(accessToken, refreshToken);
     }
 

--- a/src/main/java/com/zerobase/foodlier/common/security/provider/JwtTokenProvider.java
+++ b/src/main/java/com/zerobase/foodlier/common/security/provider/JwtTokenProvider.java
@@ -5,17 +5,14 @@ import com.zerobase.foodlier.common.redis.dto.RefreshTokenDto;
 import com.zerobase.foodlier.common.redis.service.RefreshTokenService;
 import com.zerobase.foodlier.common.security.exception.JwtException;
 import com.zerobase.foodlier.common.security.provider.constants.TokenExpiredConstant;
-import com.zerobase.foodlier.common.security.provider.dto.CreateTokenDto;
 import com.zerobase.foodlier.common.security.provider.dto.MemberAuthDto;
 import com.zerobase.foodlier.common.security.provider.dto.TokenDto;
 import io.jsonwebtoken.*;
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
 import java.util.Date;
 import java.util.List;
@@ -24,52 +21,82 @@ import java.util.stream.Collectors;
 import static com.zerobase.foodlier.common.security.exception.JwtErrorCode.*;
 
 @Component
-@RequiredArgsConstructor
 public class JwtTokenProvider {
 
     private static final String KEY_ROLES = "roles";
 
     private final TokenExpiredConstant tokenExpiredConstant;
     private final RefreshTokenService refreshTokenService;
+    private final String accessSecretKey;
 
-    @Value("${spring.jwt.secret}")
-    private String accessSecretKey;
-
-    public String createAccessToken(MemberAuthDto memberAuthDto) {
-        return setToken(CreateTokenDto.builder()
-                .id(memberAuthDto.getId())
-                .email(memberAuthDto.getEmail())
-                .roles(memberAuthDto.getRoles())
-                .keyRoles(KEY_ROLES)
-                .tokenExpiredTime(tokenExpiredConstant.getAccessTokenExpiredTime())
-                .secretKey(accessSecretKey)
-                .build());
+    public JwtTokenProvider(@Value("${spring.jwt.secret}") String accessSecretKey,
+                            TokenExpiredConstant tokenExpiredConstant,
+                            RefreshTokenService refreshTokenService) {
+        this.accessSecretKey = accessSecretKey;
+        this.refreshTokenService = refreshTokenService;
+        this.tokenExpiredConstant = tokenExpiredConstant;
     }
 
-    public String createRefreshToken(MemberAuthDto memberAuthDto) {
-        return setToken(CreateTokenDto.builder()
-                .id(memberAuthDto.getId())
-                .email(memberAuthDto.getEmail())
-                .tokenExpiredTime(tokenExpiredConstant.getRefreshTokenExpiredTime())
-                .secretKey(accessSecretKey)
-                .build());
+    /**
+     * 작성자: 이종욱
+     * 작성일: 2023-09-26
+     * 사용자 정보를 바탕으로 접근 토큰 생성
+     */
+    public String createAccessToken(MemberAuthDto memberAuthDto, Date date) {
+        Claims claims = Jwts.claims().setSubject(memberAuthDto.getEmail());
+        claims.setId(String.valueOf(memberAuthDto.getId()));
+        claims.put(KEY_ROLES, memberAuthDto.getRoles());
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(date)
+                .setExpiration(tokenExpiredConstant.getAccessTokenExpiredDate(date))
+                .signWith(SignatureAlgorithm.HS512, accessSecretKey)
+                .compact();
     }
 
-    public TokenDto createToken(MemberAuthDto memberAuthDto) {
+    /**
+     * 작성자: 이종욱
+     * 작성일: 2023-09-26
+     * 사용자 정보를 바탕으로 재발급 토큰 생성
+     */
+    public String createRefreshToken(MemberAuthDto memberAuthDto, Date date) {
+        Claims claims = Jwts.claims().setSubject(memberAuthDto.getEmail());
+        claims.setId(String.valueOf(memberAuthDto.getId()));
 
-        String accessToken = createAccessToken(memberAuthDto);
-        String refreshToken = createRefreshToken(memberAuthDto);
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(date)
+                .setExpiration(tokenExpiredConstant.getRefreshTokenExpiredDate(date))
+                .signWith(SignatureAlgorithm.HS512, accessSecretKey)
+                .compact();
+    }
+
+    /**
+     * 작성자: 이종욱
+     * 작성일: 2023-09-26
+     * 사용자 정보를 바탕으로 접근 토큰과 재발급 토큰 생성
+     */
+    public TokenDto createToken(MemberAuthDto memberAuthDto, Date date) {
+
+        String accessToken = createAccessToken(memberAuthDto, date);
+        String refreshToken = createRefreshToken(memberAuthDto, date);
 
         refreshTokenService.save(RefreshTokenDto.builder()
                 .memberEmail(memberAuthDto.getEmail())
                 .refreshToken(refreshToken)
-                .timeToLive(tokenExpiredConstant.getRefreshTokenExpiredTime())
+                .timeToLive(tokenExpiredConstant.getRefreshTokenExpiredMinute())
                 .build());
-
+        
         return new TokenDto(accessToken, refreshToken);
     }
 
-    public String reissue(String accessToken) {
+    /**
+     * 작성자: 이종욱
+     * 작성일: 2023-09-26
+     * 접근 토큰 만료 시 재발급 토큰이 유효할 경우 새로운 접근 토큰 발급
+     */
+    public String reissue(String accessToken, Date date) {
         Claims accessTokenClaims = this.parseClaims(accessToken);
         String userEmail = accessTokenClaims.getSubject();
         Long userId = Long.parseLong(accessTokenClaims.getId());
@@ -78,33 +105,27 @@ public class JwtTokenProvider {
             throw new JwtException(REFRESH_TOKEN_NOT_FOUND);
         }
         return this.createAccessToken(MemberAuthDto.builder()
-                .id(userId)
-                .email(userEmail)
-                .roles(roles)
-                .build());
+                        .id(userId)
+                        .email(userEmail)
+                        .roles(roles)
+                        .build(),
+                date);
     }
 
+    /**
+     * 작성자: 이종욱
+     * 작성일: 2023-09-26
+     * 사용자의 재발급 토큰 삭제
+     */
     public void deleteRefreshToken(String email) {
         refreshTokenService.delete(email);
     }
 
-    public String setToken(CreateTokenDto createTokenDto) {
-        Claims claims = Jwts.claims().setSubject(createTokenDto.getEmail());
-        claims.setId(String.valueOf(createTokenDto.getId()));
-        if (StringUtils.hasText(createTokenDto.getKeyRoles())) {
-            claims.put(createTokenDto.getKeyRoles(), createTokenDto.getRoles());
-        }
-
-        Date now = new Date();
-        Date expiredDate = new Date(now.getTime() + createTokenDto.getTokenExpiredTime());
-        return Jwts.builder()
-                .setClaims(claims)
-                .setIssuedAt(now)
-                .setExpiration(expiredDate)
-                .signWith(SignatureAlgorithm.HS512, createTokenDto.getSecretKey())
-                .compact();
-    }
-
+    /**
+     * 작성자: 이종욱
+     * 작성일: 2023-09-26
+     * 사용자의 이메일, 식별자와 권한 정보를 토큰에서 추출
+     */
     public Authentication getAuthentication(String token) {
         MemberAuthDto memberAuthDto = getMemberAuthDto(token);
         List<SimpleGrantedAuthority> grantedAuthorities =
@@ -116,6 +137,11 @@ public class JwtTokenProvider {
                 memberAuthDto, token, grantedAuthorities);
     }
 
+    /**
+     * 작성자: 이종욱
+     * 작성일: 2023-09-26
+     * 사용자의 권한을 토큰으로부터 얻음
+     */
     private List<String> getRoles(String token) {
         Claims claims = parseClaims(token);
         List<?> list = claims.get(KEY_ROLES, List.class);
@@ -125,6 +151,11 @@ public class JwtTokenProvider {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * 작성자: 이종욱
+     * 작성일: 2023-09-26
+     * 사용자의 정보 객체를 토큰으로부터 생성
+     */
     private MemberAuthDto getMemberAuthDto(String token) {
         Claims claims = parseClaims(token);
         List<String> roles = getRoles(token);
@@ -136,6 +167,11 @@ public class JwtTokenProvider {
                 .build();
     }
 
+    /**
+     * 작성자: 이종욱
+     * 작성일: 2023-09-26
+     * 접근 토큰으로부터 사용자의 이메일을 얻어 재발급 토큰 저장 유무 판별
+     */
     public boolean existRefreshToken(String accessToken) {
 
         Claims claims = this.parseClaims(accessToken);
@@ -144,11 +180,21 @@ public class JwtTokenProvider {
         return refreshTokenService.isRefreshTokenExisted(memberEmail);
     }
 
+    /**
+     * 작성자: 이종욱
+     * 작성일: 2023-09-26
+     * 전달받은 토큰의 만료 여부 판별
+     */
     public boolean isTokenExpired(String token) {
         Claims claims = this.parseClaims(token);
         return claims.getExpiration().before(new Date());
     }
 
+    /**
+     * 작성자: 이종욱
+     * 작성일: 2023-09-26
+     * 전달받은 토큰을 비밀 키로 복호화하여 토큰 정보 추출
+     */
     private Claims parseClaims(String token) {
         try {
             return Jwts.parser().setSigningKey(this.accessSecretKey).parseClaimsJws(token).getBody();

--- a/src/main/java/com/zerobase/foodlier/common/security/provider/constants/TokenExpiredConstant.java
+++ b/src/main/java/com/zerobase/foodlier/common/security/provider/constants/TokenExpiredConstant.java
@@ -3,10 +3,12 @@ package com.zerobase.foodlier.common.security.provider.constants;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-@Component
-public final class TokenExpiredConstant {
+import java.util.Date;
 
-    private final Long THOUSAND = 1000L;
+@Component
+public class TokenExpiredConstant {
+
+    private final Long MILLISECOND = 1000L;
 
     @Value("${spring.token-expired.access.second}")
     private long accessSecond;
@@ -31,12 +33,23 @@ public final class TokenExpiredConstant {
     }
 
     public long getAccessTokenExpiredTime() {
-        return accessHour * accessMinute * accessSecond * THOUSAND;
+        return accessHour * accessMinute * accessSecond * MILLISECOND;
     }
 
     public long getRefreshTokenExpiredTime() {
+        return refreshHour * refreshMinute * refreshSecond * MILLISECOND;
+    }
+
+    public long getRefreshTokenExpiredMinute() {
         return refreshHour * refreshMinute * refreshSecond;
     }
 
+    public Date getAccessTokenExpiredDate(Date date) {
+        return new Date(date.getTime() + getAccessTokenExpiredTime());
+    }
+
+    public Date getRefreshTokenExpiredDate(Date date) {
+        return new Date(date.getTime() + getRefreshTokenExpiredTime());
+    }
 
 }

--- a/src/main/java/com/zerobase/foodlier/module/member/member/dto/SignInForm.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/member/dto/SignInForm.java
@@ -1,9 +1,12 @@
 package com.zerobase.foodlier.module.member.member.dto;
 
 import lombok.*;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
+import java.util.Date;
 
 @Getter
 @Setter
@@ -16,4 +19,10 @@ public class SignInForm {
     private String email;
     @NotBlank(message = "비밀번호를 입력해 주세요")
     private String password;
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'hh:mm:ss")
+    private LocalDateTime currentDate;
+
+    public Date getCurrentDate(){
+        return java.sql.Timestamp.valueOf(this.currentDate);
+    }
 }

--- a/src/main/java/com/zerobase/foodlier/module/member/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/member/service/MemberServiceImpl.java
@@ -59,8 +59,8 @@ public class MemberServiceImpl implements MemberService {
     }
 
     /**
-     * 작성자 : 이승현
-     * 작성일 : 2023-09-24(2023-09-25)
+     * 작성자 : 이승현, 이종욱
+     * 작성일 : 2023-09-24(2023-09-25, 2023-09-26)
      * 이메일과 비밀번호를 받아와서 access token과 refresh token값을 반환해줍니다.
      */
     @Override

--- a/src/main/java/com/zerobase/foodlier/module/member/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/member/service/MemberServiceImpl.java
@@ -71,10 +71,11 @@ public class MemberServiceImpl implements MemberService {
                 .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
 
         return tokenProvider.createToken(MemberAuthDto.builder()
-                .id(member.getId())
-                .email(member.getEmail())
-                .roles(member.getRoles())
-                .build());
+                        .id(member.getId())
+                        .email(member.getEmail())
+                        .roles(member.getRoles())
+                        .build(),
+                form.getCurrentDate());
     }
 
     /**

--- a/src/test/java/com/zerobase/foodlier/common/security/provider/JwtTokenProviderTest.java
+++ b/src/test/java/com/zerobase/foodlier/common/security/provider/JwtTokenProviderTest.java
@@ -1,0 +1,347 @@
+package com.zerobase.foodlier.common.security.provider;
+
+import com.zerobase.foodlier.common.redis.dto.RefreshTokenDto;
+import com.zerobase.foodlier.common.redis.service.RefreshTokenService;
+import com.zerobase.foodlier.common.security.exception.JwtErrorCode;
+import com.zerobase.foodlier.common.security.exception.JwtException;
+import com.zerobase.foodlier.common.security.provider.constants.TokenExpiredConstant;
+import com.zerobase.foodlier.common.security.provider.dto.MemberAuthDto;
+import com.zerobase.foodlier.common.security.provider.dto.TokenDto;
+import com.zerobase.foodlier.module.member.member.type.RoleType;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.Authentication;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+public class JwtTokenProviderTest {
+    private static final int TRY_ONCE = 1;
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
+    @Mock
+    private TokenExpiredConstant tokenExpiredConstant;
+
+    private JwtTokenProvider jwtTokenProvider;
+
+    private final String accessSecretKey = "secret_key"; // Access secret key for testing
+    private final Long accessTokenExpiredTime = 36000000L;
+    private final Long refreshTokenExpiredTime = 24 * 36000000L;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        jwtTokenProvider = new JwtTokenProvider(accessSecretKey,
+                tokenExpiredConstant,
+                refreshTokenService
+        );
+    }
+
+    Claims parseClaims(String token) {
+        return Jwts.parser().setSigningKey(accessSecretKey)
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    @Test
+    @DisplayName("접근 토큰 발급 성공")
+    void success_Create_AccessToken() {
+
+        // given
+        MemberAuthDto memberAuthDto = MemberAuthDto.builder()
+                .id(1L)
+                .email("test@gmail.com")
+                .roles(List.of(RoleType.ROLE_USER.name()))
+                .build();
+        Date date = new Date();
+        Date expiredDate = new Date(date.getTime() + accessTokenExpiredTime);
+        when(tokenExpiredConstant.getAccessTokenExpiredDate(date))
+                .thenReturn(expiredDate);
+
+        // when
+        String accessToken = jwtTokenProvider.createAccessToken(memberAuthDto, date);
+
+        // then
+        Claims claims = parseClaims(accessToken);
+        Date actualExpiredDate = claims.get("exp", Date.class);
+        LocalDateTime expectedExpired = transformFrom(expiredDate);
+        LocalDateTime actualExpired = transformFrom(actualExpiredDate);
+        assertAll(
+                () -> assertEquals(claims.getSubject(), memberAuthDto.getEmail()),
+                () -> assertEquals(Long.parseLong(claims.getId()), memberAuthDto.getId()),
+                () -> assertEquals(claims.get("roles"), memberAuthDto.getRoles()),
+                () -> assertEquals(expectedExpired, actualExpired)
+
+        );
+    }
+
+    @Test
+    @DisplayName("재발급 토큰 발급 성공")
+    void success_Create_RefreshToken() {
+
+        // given
+        MemberAuthDto memberAuthDto = MemberAuthDto.builder()
+                .id(1L)
+                .email("test@gmail.com")
+                .roles(List.of(RoleType.ROLE_USER.name()))
+                .build();
+        Date date = new Date();
+        Date expectedExpiredDate = new Date(date.getTime() + refreshTokenExpiredTime);
+        when(tokenExpiredConstant.getRefreshTokenExpiredDate(date))
+                .thenReturn(expectedExpiredDate);
+
+        // when
+        String accessToken = jwtTokenProvider.createRefreshToken(memberAuthDto, date);
+
+        // then
+        Claims claims = parseClaims(accessToken);
+        Date actualExpiredDate = claims.get("exp", Date.class);
+        LocalDateTime expectedExpired = transformFrom(expectedExpiredDate);
+        LocalDateTime actualExpired = transformFrom(actualExpiredDate);
+        assertAll(
+                () -> assertEquals(claims.getSubject(), memberAuthDto.getEmail()),
+                () -> assertEquals(Long.parseLong(claims.getId()), memberAuthDto.getId()),
+                () -> assertEquals(expectedExpired, actualExpired)
+
+        );
+    }
+
+    @Test
+    @DisplayName("접근 토큰과 재발급 토큰 발급 성공")
+    void success_Create_Token_All() {
+
+        // given
+        MemberAuthDto memberAuthDto = MemberAuthDto.builder()
+                .id(1L)
+                .email("test@gmail.com")
+                .roles(List.of(RoleType.ROLE_USER.name()))
+                .build();
+        Date date = new Date();
+        Date accessTokenExpiredDate = new Date(date.getTime() + accessTokenExpiredTime);
+        Date refreshTokenExpiredDate = new Date(date.getTime() + refreshTokenExpiredTime);
+
+        when(tokenExpiredConstant.getAccessTokenExpiredDate(date))
+                .thenReturn(accessTokenExpiredDate);
+        when(tokenExpiredConstant.getRefreshTokenExpiredDate(date))
+                .thenReturn(refreshTokenExpiredDate);
+        when(tokenExpiredConstant.getRefreshTokenExpiredMinute())
+                .thenReturn(refreshTokenExpiredTime);
+        doNothing().when(refreshTokenService).save(any());
+        // when
+        ArgumentCaptor<RefreshTokenDto> captor = ArgumentCaptor.forClass(RefreshTokenDto.class);
+
+        TokenDto tokenDto = jwtTokenProvider.createToken(memberAuthDto, date);
+
+        // then
+        verify(refreshTokenService, times(TRY_ONCE)).save(captor.capture());
+
+        assertAll(
+                () -> assertNotNull(tokenDto.getAccessToken()),
+                () -> assertNotNull(tokenDto.getRefreshToken()),
+                () -> assertEquals(captor.getValue().getMemberEmail(), memberAuthDto.getEmail()),
+                () -> assertEquals(captor.getValue().getRefreshToken(), tokenDto.getRefreshToken()),
+                () -> assertEquals(captor.getValue().getTimeToLive(), refreshTokenExpiredTime)
+        );
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 성공")
+    void success_Reissue_Token_All() {
+
+        // given
+        MemberAuthDto memberAuthDto = MemberAuthDto.builder()
+                .id(1L)
+                .email("test@gmail.com")
+                .roles(List.of(RoleType.ROLE_USER.name()))
+                .build();
+
+        Date date = new Date();
+        Date expectedAccessTokenExpiredDate = new Date(date.getTime() + accessTokenExpiredTime);
+
+        when(tokenExpiredConstant.getAccessTokenExpiredDate(date))
+                .thenReturn(date);
+        String accessToken = jwtTokenProvider.createAccessToken(memberAuthDto, date);
+
+        given(refreshTokenService.isRefreshTokenExisted(anyString()))
+                .willReturn(true);
+
+        when(tokenExpiredConstant.getAccessTokenExpiredDate(date))
+                .thenReturn(expectedAccessTokenExpiredDate);
+
+        // when
+
+        String reissue = jwtTokenProvider.reissue(accessToken, date);
+
+        // then
+        Claims claims = parseClaims(reissue);
+        Date actualExpiredDate = claims.get("exp", Date.class);
+        LocalDateTime expectedExpired = transformFrom(expectedAccessTokenExpiredDate);
+
+        LocalDateTime actualExpired = transformFrom(actualExpiredDate);
+        assertAll(
+                () -> assertEquals(claims.getSubject(), memberAuthDto.getEmail()),
+                () -> assertEquals(Long.parseLong(claims.getId()), memberAuthDto.getId()),
+                () -> assertEquals(expectedExpired, actualExpired)
+
+        );
+    }
+
+
+    @Test
+    @DisplayName("토큰 재발급 실패 - 재발급 토큰 만료")
+    void fail_Reissue_Token_All() {
+
+        // given
+        MemberAuthDto memberAuthDto = MemberAuthDto.builder()
+                .id(1L)
+                .email("test@gmail.com")
+                .roles(List.of(RoleType.ROLE_USER.name()))
+                .build();
+
+        Date date = new Date();
+
+        when(tokenExpiredConstant.getAccessTokenExpiredDate(date))
+                .thenReturn(date);
+        String accessToken = jwtTokenProvider.createAccessToken(memberAuthDto, date);
+
+        given(refreshTokenService.isRefreshTokenExisted(anyString()))
+                .willReturn(false);
+
+        // when
+        JwtException jwtException = assertThrows(JwtException.class, () -> jwtTokenProvider.reissue(accessToken, date));
+        // then
+
+        assertAll(
+                () -> assertEquals(jwtException.getErrorCode(), JwtErrorCode.REFRESH_TOKEN_NOT_FOUND),
+                () -> assertEquals(jwtException.getDescription(), JwtErrorCode.REFRESH_TOKEN_NOT_FOUND.getDescription())
+        );
+    }
+
+    @Test
+    @DisplayName("인증 정보 생성 성공")
+    void success_create_authentication() {
+
+        // given
+        MemberAuthDto memberAuthDto = MemberAuthDto.builder()
+                .id(1L)
+                .email("test@gmail.com")
+                .roles(List.of(RoleType.ROLE_USER.name()))
+                .build();
+
+        Date date = new Date();
+
+        when(tokenExpiredConstant.getAccessTokenExpiredDate(date))
+                .thenReturn(new Date(date.getTime() + accessTokenExpiredTime));
+        String accessToken = jwtTokenProvider.createAccessToken(memberAuthDto, date);
+
+        // when
+        Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+
+        // then
+        Object principal = authentication.getPrincipal();
+        MemberAuthDto actualMemberAuthDto = (MemberAuthDto) principal;
+        assertAll(
+                () -> assertEquals(memberAuthDto.getId(), actualMemberAuthDto.getId()),
+                () -> assertEquals(memberAuthDto.getEmail(), actualMemberAuthDto.getEmail()),
+                () -> assertEquals(memberAuthDto.getRoles(), actualMemberAuthDto.getRoles())
+        );
+    }
+
+    @Test
+    @DisplayName("재발급 토큰 삭제 성공")
+    void success_delete_refresh_token(){
+
+        // given
+        MemberAuthDto memberAuthDto = MemberAuthDto.builder()
+                .id(1L)
+                .email("test@gmail.com")
+                .roles(List.of(RoleType.ROLE_USER.name()))
+                .build();
+
+        // when
+
+        jwtTokenProvider.deleteRefreshToken(memberAuthDto.getEmail());
+
+        // then
+        verify(refreshTokenService, times(TRY_ONCE)).delete(memberAuthDto.getEmail());
+
+    }
+
+    @Test
+    @DisplayName("재발급 토큰 찾기 성공")
+    void success_Find_RefreshToken(){
+
+        // given
+        MemberAuthDto memberAuthDto = MemberAuthDto.builder()
+                .id(1L)
+                .email("test@gmail.com")
+                .roles(List.of(RoleType.ROLE_USER.name()))
+                .build();
+        Date date = new Date();
+
+        when(tokenExpiredConstant.getAccessTokenExpiredDate(date))
+                .thenReturn(new Date(date.getTime() + accessTokenExpiredTime));
+        String accessToken = jwtTokenProvider.createAccessToken(memberAuthDto, date);
+
+        when(refreshTokenService.isRefreshTokenExisted(memberAuthDto.getEmail()))
+                .thenReturn(true);
+
+        // when
+
+        boolean findingResult = jwtTokenProvider.existRefreshToken(accessToken);
+
+        // then
+        assertTrue(findingResult);
+
+    }
+
+    @Test
+    @DisplayName("재발급 토큰 찾기 실패 - 재발급 토큰 저장 시간 만료")
+    void fail_Find_RefreshToken(){
+
+        // given
+        MemberAuthDto memberAuthDto = MemberAuthDto.builder()
+                .id(1L)
+                .email("test@gmail.com")
+                .roles(List.of(RoleType.ROLE_USER.name()))
+                .build();
+        Date date = new Date();
+
+        when(tokenExpiredConstant.getAccessTokenExpiredDate(date))
+                .thenReturn(new Date(date.getTime() + accessTokenExpiredTime));
+        String accessToken = jwtTokenProvider.createAccessToken(memberAuthDto, date);
+
+        when(refreshTokenService.isRefreshTokenExisted(memberAuthDto.getEmail()))
+                .thenReturn(false);
+
+        // when
+
+        boolean findingResult = jwtTokenProvider.existRefreshToken(accessToken);
+
+        // then
+        assertFalse(findingResult);
+
+    }
+
+    private LocalDateTime transformFrom(Date date){
+
+           return date.toInstant()
+                    .atZone(ZoneId.systemDefault())
+                    .toLocalDateTime()
+                    .withNano(0);
+
+    }
+}


### PR DESCRIPTION
## Summary
- jwt 발급 로직 변경
- jwt 발급 및 검증 로직 테스트

## Describe your changes

### jwt 발급 로직 변경
기존에는 jwt 발급을 요청하면 내부적으로 jwt 발급 기능 실행 시점을 기준으로 만료 시간을 설정
변경 후, jwt 발급 요청 시점을 기준으로 만료 시간 설정

만료 시간 단위 분리
refresh token이 레디스에 저장되는 시간 단위(minute)와 jwt 발급 시 사용되는 시간 단위(millisecond)가 서로 달라 단위 별로 사용할 수 있도록 만료 시간이 정의된 상수 클래스에서 단위 별로 만료 시간 분리

### jwt 발급 및 검증 로직 테스트

테스트 목록
- 접근 토큰 발급 테스트
- 재발급 토큰 발급 테스트
- 재발급 토큰 저장 테스트
- 재발급 토큰 삭제 테스트
- 사용자 정보 로딩 테스트
- 재발급 토큰 존재 여부 확인 테스트

## Issue number and link
#15