### PR TITLE
BE - 요청 보내기/취소, 수락/거절 기능

### DIFF
--- a/src/main/java/com/zerobase/foodlier/global/refrigerator/controller/RefrigeratorController.java
+++ b/src/main/java/com/zerobase/foodlier/global/refrigerator/controller/RefrigeratorController.java
@@ -15,13 +15,13 @@ public class RefrigeratorController {
     private final RequestService requestService;
     private final RefrigeratorFacade refrigeratorFacade;
 
-    @PatchMapping("/send?requestId={requestId}&chefMemberId={chefMemberId}")
+    @PatchMapping("/send")
     public ResponseEntity<String> sendRequest(
             @AuthenticationPrincipal MemberAuthDto memberAuthDto,
-            @RequestParam(name = "requestId") Long requestId,
-            @RequestParam(name = "chefMemberId") Long chefMemberId
+            @RequestParam Long requestFormId,
+            @RequestParam Long chefMemberId
     ) {
-        requestService.sendRequest(memberAuthDto, requestId, chefMemberId);
+        requestService.sendRequest(memberAuthDto.getId(), requestFormId, chefMemberId);
         return ResponseEntity.ok("요청서가 전송되었습니다.");
     }
 
@@ -30,16 +30,25 @@ public class RefrigeratorController {
             @AuthenticationPrincipal MemberAuthDto memberAuthDto,
             @PathVariable(name = "requestId") Long requestId
     ) {
-        requestService.cancelRequest(memberAuthDto, requestId);
+        requestService.cancelRequest(memberAuthDto.getId(), requestId);
         return ResponseEntity.ok("요청이 취소되었습니다.");
     }
 
-    @PatchMapping("/approve/{requestId}")
-    public ResponseEntity<String> approveRequest(
+    @PostMapping("/requester/approve/{requestId}")
+    public ResponseEntity<String> requesterApproveRequest(
             @AuthenticationPrincipal MemberAuthDto memberAuthDto,
             @PathVariable(name = "requestId") Long requestId
     ) {
-        refrigeratorFacade.validRequestAndCreateDmRoom(memberAuthDto, requestId);
+        refrigeratorFacade.requesterApproveAndCreateDm(memberAuthDto.getId(), requestId);
+        return ResponseEntity.ok("요청을 수락하였습니다.");
+    }
+
+    @PostMapping("/chef/approve/{requestId}")
+    public ResponseEntity<String> chefApproveRequest(
+            @AuthenticationPrincipal MemberAuthDto memberAuthDto,
+            @PathVariable(name = "requestId") Long requestId
+    ) {
+        refrigeratorFacade.chefApproveAndCreateDm(memberAuthDto.getId(), requestId);
         return ResponseEntity.ok("요청을 수락하였습니다.");
     }
 
@@ -48,7 +57,7 @@ public class RefrigeratorController {
             @AuthenticationPrincipal MemberAuthDto memberAuthDto,
             @PathVariable(name = "requestId") Long requestId
     ) {
-        requestService.rejectRequest(memberAuthDto, requestId);
+        requestService.rejectRequest(memberAuthDto.getId(), requestId);
         return ResponseEntity.ok("요청을 거절하였습니다.");
     }
 }

--- a/src/main/java/com/zerobase/foodlier/global/refrigerator/controller/RefrigeratorController.java
+++ b/src/main/java/com/zerobase/foodlier/global/refrigerator/controller/RefrigeratorController.java
@@ -5,6 +5,7 @@ import com.zerobase.foodlier.global.refrigerator.facade.RefrigeratorFacade;
 import com.zerobase.foodlier.module.request.service.RequestService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -43,6 +44,7 @@ public class RefrigeratorController {
         return ResponseEntity.ok("요청을 수락하였습니다.");
     }
 
+    @PreAuthorize("hasRole('CHEF')")
     @PostMapping("/chef/approve/{requestId}")
     public ResponseEntity<String> chefApproveRequest(
             @AuthenticationPrincipal MemberAuthDto memberAuthDto,
@@ -52,6 +54,7 @@ public class RefrigeratorController {
         return ResponseEntity.ok("요청을 수락하였습니다.");
     }
 
+    @PreAuthorize("hasRole('CHEF')")
     @PatchMapping("/reject/{requestId}")
     public ResponseEntity<String> rejectRequest(
             @AuthenticationPrincipal MemberAuthDto memberAuthDto,

--- a/src/main/java/com/zerobase/foodlier/global/refrigerator/facade/RefrigeratorFacade.java
+++ b/src/main/java/com/zerobase/foodlier/global/refrigerator/facade/RefrigeratorFacade.java
@@ -1,6 +1,5 @@
 package com.zerobase.foodlier.global.refrigerator.facade;
 
-import com.zerobase.foodlier.common.security.provider.dto.MemberAuthDto;
 import com.zerobase.foodlier.module.dm.room.service.DmRoomService;
 import com.zerobase.foodlier.module.request.domain.model.Request;
 import com.zerobase.foodlier.module.request.service.RequestService;
@@ -13,8 +12,13 @@ public class RefrigeratorFacade {
     private final RequestService requestService;
     private final DmRoomService dmRoomService;
 
-    public void validRequestAndCreateDmRoom(MemberAuthDto memberAuthDto, Long requestId) {
-        Request request = requestService.approveRequest(memberAuthDto, requestId);
+    public void requesterApproveAndCreateDm(Long memberId, Long requestId) {
+        Request request = requestService.requesterApproveRequest(memberId, requestId);
+        dmRoomService.createDmRoom(request);
+    }
+
+    public void chefApproveAndCreateDm(Long memberId, Long requestId){
+        Request request = requestService.chefApproveRequest(memberId, requestId);
         dmRoomService.createDmRoom(request);
     }
 }

--- a/src/main/java/com/zerobase/foodlier/global/refrigerator/facade/RefrigeratorFacade.java
+++ b/src/main/java/com/zerobase/foodlier/global/refrigerator/facade/RefrigeratorFacade.java
@@ -1,12 +1,16 @@
 package com.zerobase.foodlier.global.refrigerator.facade;
 
+import com.zerobase.foodlier.module.dm.room.domain.model.DmRoom;
 import com.zerobase.foodlier.module.dm.room.service.DmRoomService;
 import com.zerobase.foodlier.module.request.domain.model.Request;
 import com.zerobase.foodlier.module.request.service.RequestService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import javax.transaction.Transactional;
+
 @Component
+@Transactional
 @RequiredArgsConstructor
 public class RefrigeratorFacade {
     private final RequestService requestService;
@@ -14,11 +18,13 @@ public class RefrigeratorFacade {
 
     public void requesterApproveAndCreateDm(Long memberId, Long requestId) {
         Request request = requestService.requesterApproveRequest(memberId, requestId);
-        dmRoomService.createDmRoom(request);
+        DmRoom dmRoom = dmRoomService.createDmRoom(request);
+        requestService.setDmRoom(request, dmRoom);
     }
 
     public void chefApproveAndCreateDm(Long memberId, Long requestId){
         Request request = requestService.chefApproveRequest(memberId, requestId);
-        dmRoomService.createDmRoom(request);
+        DmRoom dmRoom = dmRoomService.createDmRoom(request);
+        requestService.setDmRoom(request, dmRoom);
     }
 }

--- a/src/main/java/com/zerobase/foodlier/module/dm/room/service/DmRoomService.java
+++ b/src/main/java/com/zerobase/foodlier/module/dm/room/service/DmRoomService.java
@@ -1,7 +1,8 @@
 package com.zerobase.foodlier.module.dm.room.service;
 
+import com.zerobase.foodlier.module.dm.room.domain.model.DmRoom;
 import com.zerobase.foodlier.module.request.domain.model.Request;
 
 public interface DmRoomService {
-    void createDmRoom(Request request);
+    DmRoom createDmRoom(Request request);
 }

--- a/src/main/java/com/zerobase/foodlier/module/dm/room/service/DmRoomServiceImpl.java
+++ b/src/main/java/com/zerobase/foodlier/module/dm/room/service/DmRoomServiceImpl.java
@@ -11,14 +11,15 @@ import org.springframework.stereotype.Service;
 public class DmRoomServiceImpl implements DmRoomService {
     private final DmRoomRepository dmRoomRepository;
 
+
     /**
      * 작성자 : 이승현
      * 작성일 : 2023-09-27
      * 요청을 수락 시 DM 방이 생성됩니다.
      */
     @Override
-    public void createDmRoom(Request request) {
-        dmRoomRepository.save(DmRoom.builder()
+    public DmRoom createDmRoom(Request request) {
+        return dmRoomRepository.save(DmRoom.builder()
                 .request(request)
                 .build());
     }

--- a/src/main/java/com/zerobase/foodlier/module/member/chef/service/ChefMemberServiceImpl.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/chef/service/ChefMemberServiceImpl.java
@@ -9,6 +9,7 @@ import com.zerobase.foodlier.module.member.member.domain.model.Member;
 import com.zerobase.foodlier.module.member.member.exception.MemberErrorCode;
 import com.zerobase.foodlier.module.member.member.exception.MemberException;
 import com.zerobase.foodlier.module.member.member.repository.MemberRepository;
+import com.zerobase.foodlier.module.member.member.type.RoleType;
 import com.zerobase.foodlier.module.recipe.repository.RecipeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -45,6 +46,7 @@ public class ChefMemberServiceImpl implements ChefMemberService{
 
         ChefMember chefMemberEntity = chefMemberRepository.save(chefMember);
         member.setChefMember(chefMemberEntity);
+        member.getRoles().add(RoleType.ROLE_CHEF.name());
         memberRepository.save(member);
     }
 

--- a/src/main/java/com/zerobase/foodlier/module/request/domain/model/Request.java
+++ b/src/main/java/com/zerobase/foodlier/module/request/domain/model/Request.java
@@ -1,6 +1,7 @@
 package com.zerobase.foodlier.module.request.domain.model;
 
 import com.zerobase.foodlier.common.jpa.audit.Audit;
+import com.zerobase.foodlier.module.dm.room.domain.model.DmRoom;
 import com.zerobase.foodlier.module.member.chef.domain.model.ChefMember;
 import com.zerobase.foodlier.module.member.member.domain.model.Member;
 import com.zerobase.foodlier.module.recipe.domain.model.Recipe;
@@ -45,6 +46,9 @@ public class Request extends Audit {
     @ManyToOne
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @OneToOne
+    private DmRoom dmRoom;
 
     @OneToOne
     private ChefReview chefReview;

--- a/src/main/java/com/zerobase/foodlier/module/request/domain/vo/Ingredient.java
+++ b/src/main/java/com/zerobase/foodlier/module/request/domain/vo/Ingredient.java
@@ -1,5 +1,6 @@
 package com.zerobase.foodlier.module.request.domain.vo;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import javax.persistence.Column;
@@ -7,6 +8,7 @@ import javax.persistence.Embeddable;
 
 @Embeddable
 @Getter
+@AllArgsConstructor
 public class Ingredient {
     @Column(nullable = false)
     private String ingredientName;

--- a/src/main/java/com/zerobase/foodlier/module/request/exception/RequestErrorCode.java
+++ b/src/main/java/com/zerobase/foodlier/module/request/exception/RequestErrorCode.java
@@ -9,7 +9,15 @@ public enum RequestErrorCode {
     REQUEST_NOT_FOUND("존재하지 않는 요청서입니다."),
     MEMBER_REQUEST_NOT_MATCH("요청서의 작성자와 일치하지 않습니다."),
     CHEF_MEMBER_REQUEST_NOT_MATCH("요청서의 요리사와 일치하지 않습니다."),
-    NEW_ENUM("enum 추가");
+    ALREADY_REQUESTED_CHEF("이미 요청한 요리사입니다."),
+    CANNOT_CANCEL_APPROVED("수락한 요청은 취소할 수 없습니다."),
+    CANNOT_CANCEL_IS_PAID("결제된 요청은 취소할 수 없습니다."),
+    CANNOT_REQUESTER_APPROVE_HAS_NOT_QUOTATION("견적서가 없는 요청을 수락할 수 없습니다."),
+    CANNOT_REQUESTER_APPROVE_IS_NOT_QUOTATION("견적서가 아닌 요청을 수락할 수 없습니다."),
+    CANNOT_CHEF_APPROVE_HAS_NOT_RECIPE("요청서에 태깅된 레시피가 존재하지 않습니다."),
+    CANNOT_CHEF_APPROVE_IS_QUOTATION("견적서인 요청을 수락할 수 없습니다."),
+    ALREADY_APPROVED("이미 수락된 요청입니다."),
+    ;
 
     private final String description;
 }

--- a/src/main/java/com/zerobase/foodlier/module/request/exception/RequestErrorCode.java
+++ b/src/main/java/com/zerobase/foodlier/module/request/exception/RequestErrorCode.java
@@ -17,6 +17,7 @@ public enum RequestErrorCode {
     CANNOT_CHEF_APPROVE_HAS_NOT_RECIPE("요청서에 태깅된 레시피가 존재하지 않습니다."),
     CANNOT_CHEF_APPROVE_IS_QUOTATION("견적서인 요청을 수락할 수 없습니다."),
     ALREADY_APPROVED("이미 수락된 요청입니다."),
+    CANNOT_REQUEST_TO_ME("자기 자신에 대한 요청은 불가능 합니다."),
     ;
 
     private final String description;

--- a/src/main/java/com/zerobase/foodlier/module/request/repository/RequestRepository.java
+++ b/src/main/java/com/zerobase/foodlier/module/request/repository/RequestRepository.java
@@ -1,7 +1,17 @@
 package com.zerobase.foodlier.module.request.repository;
 
+import com.zerobase.foodlier.module.member.chef.domain.model.ChefMember;
+import com.zerobase.foodlier.module.member.member.domain.model.Member;
 import com.zerobase.foodlier.module.request.domain.model.Request;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RequestRepository extends JpaRepository<Request, Long> {
+
+
+    /**
+     *  Member가 ChefMember에게 요청한 이력이 있는지 확인함.
+     */
+    boolean existsByMemberAndChefMemberAndIsPaid(
+            Member member, ChefMember chefMember, boolean isPaid
+    );
 }

--- a/src/main/java/com/zerobase/foodlier/module/request/repository/RequestRepository.java
+++ b/src/main/java/com/zerobase/foodlier/module/request/repository/RequestRepository.java
@@ -11,7 +11,7 @@ public interface RequestRepository extends JpaRepository<Request, Long> {
     /**
      *  Member가 ChefMember에게 요청한 이력이 있는지 확인함.
      */
-    boolean existsByMemberAndChefMemberAndIsPaid(
-            Member member, ChefMember chefMember, boolean isPaid
+    boolean existsByMemberAndChefMemberAndIsPaidFalse(
+            Member member, ChefMember chefMember
     );
 }

--- a/src/main/java/com/zerobase/foodlier/module/request/service/RequestService.java
+++ b/src/main/java/com/zerobase/foodlier/module/request/service/RequestService.java
@@ -1,8 +1,11 @@
 package com.zerobase.foodlier.module.request.service;
 
+import com.zerobase.foodlier.module.dm.room.domain.model.DmRoom;
 import com.zerobase.foodlier.module.request.domain.model.Request;
 
 public interface RequestService {
+
+    void setDmRoom(Request request, DmRoom dmRoom);
     void sendRequest(Long memberId, Long requestFormId, Long chefMemberId);
 
     void cancelRequest(Long memberId, Long requestId);

--- a/src/main/java/com/zerobase/foodlier/module/request/service/RequestService.java
+++ b/src/main/java/com/zerobase/foodlier/module/request/service/RequestService.java
@@ -1,14 +1,15 @@
 package com.zerobase.foodlier.module.request.service;
 
-import com.zerobase.foodlier.common.security.provider.dto.MemberAuthDto;
 import com.zerobase.foodlier.module.request.domain.model.Request;
 
 public interface RequestService {
-    void sendRequest(MemberAuthDto memberAuthDto, Long requestId, Long chefMemberId);
+    void sendRequest(Long memberId, Long requestFormId, Long chefMemberId);
 
-    void cancelRequest(MemberAuthDto memberAuthDto, Long requestId);
+    void cancelRequest(Long memberId, Long requestId);
 
-    Request approveRequest(MemberAuthDto memberAuthDto, Long requestId);
+    Request requesterApproveRequest(Long memberId, Long requestId);
 
-    void rejectRequest(MemberAuthDto memberAuthDto, Long requestId);
+    Request chefApproveRequest(Long memberId, Long requestId);
+
+    void rejectRequest(Long memberId, Long requestId);
 }

--- a/src/main/java/com/zerobase/foodlier/module/request/service/RequestServiceImpl.java
+++ b/src/main/java/com/zerobase/foodlier/module/request/service/RequestServiceImpl.java
@@ -15,7 +15,6 @@ import com.zerobase.foodlier.module.requestform.domain.model.RequestForm;
 import com.zerobase.foodlier.module.requestform.exception.RequestFormException;
 import com.zerobase.foodlier.module.requestform.repository.RequestFormRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.Objects;
@@ -157,8 +156,8 @@ public class RequestServiceImpl implements RequestService {
         if(Objects.equals(member.getId(), chefMember.getMember().getId())){
             throw new RequestException(CANNOT_REQUEST_TO_ME);
         }
-        if(requestRepository.existsByMemberAndChefMemberAndIsPaid(
-                member, chefMember, false
+        if(requestRepository.existsByMemberAndChefMemberAndIsPaidFalse(
+                member, chefMember
         )){
             throw new RequestException(ALREADY_REQUESTED_CHEF);
         }

--- a/src/main/java/com/zerobase/foodlier/module/request/service/RequestServiceImpl.java
+++ b/src/main/java/com/zerobase/foodlier/module/request/service/RequestServiceImpl.java
@@ -1,104 +1,198 @@
 package com.zerobase.foodlier.module.request.service;
 
-import com.zerobase.foodlier.common.security.provider.dto.MemberAuthDto;
+import com.zerobase.foodlier.module.member.chef.domain.model.ChefMember;
 import com.zerobase.foodlier.module.member.chef.exception.ChefMemberException;
 import com.zerobase.foodlier.module.member.chef.repository.ChefMemberRepository;
+import com.zerobase.foodlier.module.member.member.domain.model.Member;
+import com.zerobase.foodlier.module.member.member.exception.MemberException;
+import com.zerobase.foodlier.module.member.member.repository.MemberRepository;
 import com.zerobase.foodlier.module.request.domain.model.Request;
 import com.zerobase.foodlier.module.request.exception.RequestException;
 import com.zerobase.foodlier.module.request.repository.RequestRepository;
+import com.zerobase.foodlier.module.requestform.domain.model.RequestForm;
+import com.zerobase.foodlier.module.requestform.exception.RequestFormException;
+import com.zerobase.foodlier.module.requestform.repository.RequestFormRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.Objects;
 
 import static com.zerobase.foodlier.module.member.chef.exception.ChefMemberErrorCode.CHEF_MEMBER_NOT_FOUND;
+import static com.zerobase.foodlier.module.member.member.exception.MemberErrorCode.MEMBER_NOT_FOUND;
 import static com.zerobase.foodlier.module.request.exception.RequestErrorCode.*;
+import static com.zerobase.foodlier.module.requestform.exception.RequestFormErrorCode.REQUEST_FORM_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
 public class RequestServiceImpl implements RequestService {
     private final RequestRepository requestRepository;
+    private final RequestFormRepository requestFormRepository;
     private final ChefMemberRepository chefMemberRepository;
+    private final MemberRepository memberRepository;
+
 
     /**
-     * 작성자 : 이승현
-     * 작성일 : 2023-09-27
-     * 요청서를 보냅니다.
+     *  작성자 : 전현서
+     *  작성일 : 2023-09-28
+     *
+     *  요청을 보내는 메서드, 같은 요리사에게는 중복 요청 X
      */
     @Override
-    public void sendRequest(MemberAuthDto memberAuthDto, Long requestId, Long chefMemberId) {
-        Request request = findById(requestId);
-        validRequestMember(memberAuthDto, request);
-        request.setChefMember(chefMemberRepository.findById(chefMemberId)
-                .orElseThrow(() -> new ChefMemberException(CHEF_MEMBER_NOT_FOUND)));
+    public void sendRequest(Long memberId, Long requestFormId, Long chefMemberId) {
+        Member member = getMember(memberId);
+
+        ChefMember chefMember = chefMemberRepository.findById(chefMemberId)
+                .orElseThrow(() -> new ChefMemberException(CHEF_MEMBER_NOT_FOUND));
+
+        validateSendRequest(member, chefMember);
+
+        RequestForm requestForm = requestFormRepository.findById(requestFormId)
+                .orElseThrow(() -> new RequestFormException(REQUEST_FORM_NOT_FOUND));
+
+        Request request = Request.builder()
+                .member(member)
+                .chefMember(chefMember)
+                .title(requestForm.getTitle())
+                .content(requestForm.getContent())
+                .ingredientList(requestForm.getIngredientList())
+                .expectPrice(requestForm.getExpectPrice())
+                .expectedAt(requestForm.getExpectedAt())
+                .recipe(requestForm.getRecipe())
+                .isPaid(false)
+                .build();
 
         requestRepository.save(request);
     }
 
     /**
-     * 작성자 : 이승현
-     * 작성일 : 2023-09-27
-     * 요청을 거절합니다.
+     *  작성자 : 전현서
+     *  작성일 : 2023-09-28
+     *  요청자가 보낸 요청을 취소함, 성사된 요청 취소 X
      */
     @Override
-    public void cancelRequest(MemberAuthDto memberAuthDto, Long requestId) {
-        Request request = findById(requestId);
-        validRequestMember(memberAuthDto, request);
-        request.setChefMember(null);
+    public void cancelRequest(Long memberId, Long requestId) {
+        Member member = getMember(memberId);
+        Request request = getRequest(requestId);
 
-        requestRepository.save(request);
+        validateCancelRequest(member, request);
+
+        requestRepository.delete(request);
     }
 
     /**
-     * 작성자 : 이승현
-     * 작성일 : 2023-09-27
-     * 요청을 수락합니다.
+     *  작성자 : 전현서
+     *  작성일 : 2023-09-28
+     *  요청자가 견적서를 보고 해당 요청에 대해 승인을 수행함.
      */
     @Override
-    public Request approveRequest(MemberAuthDto memberAuthDto, Long requestId) {
-        Request request = findById(requestId);
-        if (request.getRecipe().getIsQuotation()) {
-            validRequestMember(memberAuthDto, request);
-        } else {
-            validRequestChefMember(memberAuthDto, request);
-        }
+    public Request requesterApproveRequest(Long memberId, Long requestId) {
+        Member member = getMember(memberId);
+        Request request = getRequest(requestId);
+
+        validateRequesterApproveRequest(member, request);
 
         return request;
     }
 
     /**
-     * 작성자 : 이승현
-     * 작성일 : 2023-09-27
-     * 요청을 거절합니다.
+     *  작성자 : 전현서
+     *  작성일 : 2023-09-28
+     *  요리사가 요청을 보고 수락함 (태깅된 요청에 한해서)
      */
     @Override
-    public void rejectRequest(MemberAuthDto memberAuthDto, Long requestId) {
-        Request request = findById(requestId);
-        if (request.getRecipe().getIsQuotation()) {
-            validRequestMember(memberAuthDto, request);
-            request.setRecipe(null);
-        } else {
-            validRequestChefMember(memberAuthDto, request);
-        }
-        request.setChefMember(null);
+    public Request chefApproveRequest(Long memberId, Long requestId) {
+        Member member = getMember(memberId);
+        Request request = getRequest(requestId);
 
-        requestRepository.save(request);
+        validateChefApproveRequest(member, request);
+        return request;
     }
 
-    private Request findById(Long requestId) {
+    /**
+     *  작성자 : 전현서
+     *  작성일 : 2023-09-28
+     *  요리사가 요청을 거절함.
+     */
+    @Override
+    public void rejectRequest(Long memberId, Long requestId) {
+        Member member = getMember(memberId);
+        Request request = getRequest(requestId);
+
+        validateRejectRequest(member, request);
+        requestRepository.delete(request);
+    }
+
+    private Member getMember(Long memberId){
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+    }
+
+    private Request getRequest(Long requestId){
         return requestRepository.findById(requestId)
                 .orElseThrow(() -> new RequestException(REQUEST_NOT_FOUND));
     }
 
-    private void validRequestMember(MemberAuthDto memberAuthDto, Request request) {
-        if (!Objects.equals(memberAuthDto.getId(), request.getMember().getId())) {
-            throw new RequestException(MEMBER_REQUEST_NOT_MATCH);
+
+    // ===================== Validates =======================
+    private void validateSendRequest(Member member, ChefMember chefMember){
+        if(requestRepository.existsByMemberAndChefMemberAndIsPaid(
+                member, chefMember, false
+        )){
+            throw new RequestException(ALREADY_REQUESTED_CHEF);
         }
     }
 
-    private void validRequestChefMember(MemberAuthDto memberAuthDto, Request request) {
-        if (!Objects.equals(memberAuthDto.getId(), request.getChefMember().getId())) {
+    private void validateCancelRequest(Member member, Request request){
+        if(!Objects.equals(request.getMember().getId(), member.getId())){
+            throw new RequestException(MEMBER_REQUEST_NOT_MATCH);
+        }
+        if(request.getDmRoom() != null){
+            throw new RequestException(CANNOT_CANCEL_APPROVED);
+        }
+        if(request.isPaid()){
+            throw new RequestException(CANNOT_CANCEL_IS_PAID);
+        }
+    }
+
+    private void validateRequesterApproveRequest(Member member, Request request){
+        if(!Objects.equals(request.getMember().getId(), member.getId())){
+            throw new RequestException(MEMBER_REQUEST_NOT_MATCH);
+        }
+        if(request.getRecipe() == null){
+            throw new RequestException(CANNOT_REQUESTER_APPROVE_HAS_NOT_QUOTATION);
+        }
+        if(!request.getRecipe().getIsQuotation()){
+            throw new RequestException(CANNOT_REQUESTER_APPROVE_IS_NOT_QUOTATION);
+        }
+        if(request.getDmRoom() != null){
+            throw new RequestException(ALREADY_APPROVED);
+        }
+    }
+
+    private void validateChefApproveRequest(Member member, Request request){
+        if(!Objects.equals(request.getChefMember().getMember().getId(), member.getId())){
             throw new RequestException(CHEF_MEMBER_REQUEST_NOT_MATCH);
+        }
+        if(request.getRecipe() == null){
+            throw new RequestException(CANNOT_CHEF_APPROVE_HAS_NOT_RECIPE);
+        }
+        if(request.getRecipe().getIsQuotation()){
+            throw new RequestException(CANNOT_CHEF_APPROVE_IS_QUOTATION);
+        }
+        if(request.getDmRoom() != null){
+            throw new RequestException(ALREADY_APPROVED);
+        }
+    }
+
+    private void validateRejectRequest(Member member, Request request){
+        if(!Objects.equals(request.getChefMember().getMember().getId(), member.getId())){
+            throw new RequestException(CHEF_MEMBER_REQUEST_NOT_MATCH);
+        }
+        if(request.getDmRoom() != null){
+            throw new RequestException(CANNOT_CANCEL_APPROVED);
+        }
+        if(request.isPaid()){
+            throw new RequestException(CANNOT_CANCEL_IS_PAID);
         }
     }
 }


### PR DESCRIPTION
## Summary
- ERD 설계 수정으로 인해서, 요청 보내기/취소, 수락/거절 부분을 변경함.

## Describe your changes

## 요청 보내기 sendRequest()
- 요청서를 복제하여, 요청 객체를 만듭니다.
- 이 때, 본인을 향한 요청을 막아두었고,
- 이미 같은 요리사에 대한 요청이 수락되었을 경우도, 요청이 불가합니다.

## 요청 취소하기 cancelRequest()
- dm방이 열러있지 않고, isPaid가 false경우에만, 요청 데이터를 지워 요청을 취소하게 됩니다.
- 이는 견적서를 받고, 거절하는 경우에도 같이 호출해도 무방합니다.

## 요리사가 요청 수락 chefApprovedRequest()
- 레시피가 태깅 된 경우, 요리사가 바로 수락할 수 있는 기능입니다.
- 견적서가 필요없으므로, 수락시 바로 DM Room 이 생성됩니다.

## 요청자가 요청 수락 requesterApprovedRequest()
- 레시피가 태깅되지 않은 경우, 요리사가 견적서를 보내준 상태에서
- 요청자가 해당 견적서가 마음에 들경우, 수락하게 되면 바로 DM Room이 생성됩니다.

## 요리사가 요청 거절 rejectRequest()
- 요청자로 부터 받은 요청을 거절하게 됩니다.
- 이 경우에도, dmRoom이 없어야 하고, isPaid가 false인 경우에만 가능합니다.
- 요청이 거절되면, 해당 요청은 삭제됩니다.

## Issue number and link
#82 
