### PR TITLE
BE - s3이미지 수정로직 오류로 인한 코드 수정

### DIFF
--- a/src/main/java/com/zerobase/foodlier/module/recipe/dto/ImageUrlDto.java
+++ b/src/main/java/com/zerobase/foodlier/module/recipe/dto/ImageUrlDto.java
@@ -12,6 +12,6 @@ import java.util.List;
 @Builder
 public class ImageUrlDto {
     private String mainImageUrl;
-    private List<RecipeDetail> recipeDetailList;
+    private List<String> cookingOrderImageUrlList;
 
 }

--- a/src/main/java/com/zerobase/foodlier/module/recipe/service/RecipeService.java
+++ b/src/main/java/com/zerobase/foodlier/module/recipe/service/RecipeService.java
@@ -18,7 +18,9 @@ public interface RecipeService {
 
     RecipeDtoResponse getRecipeDetail(Long id);
 
-    ImageUrlDto deleteRecipe(Long id);
+    void deleteRecipe(Long id);
 
     List<Recipe> getRecipeByTitle(String recipeTitle, Pageable pageable);
+
+    ImageUrlDto getBeforeImageUrl(Long id);
 }

--- a/src/main/java/com/zerobase/foodlier/module/recipe/service/RecipeServiceImpl.java
+++ b/src/main/java/com/zerobase/foodlier/module/recipe/service/RecipeServiceImpl.java
@@ -3,6 +3,7 @@ package com.zerobase.foodlier.module.recipe.service;
 import com.zerobase.foodlier.module.member.member.domain.model.Member;
 import com.zerobase.foodlier.module.recipe.domain.document.RecipeDocument;
 import com.zerobase.foodlier.module.recipe.domain.model.Recipe;
+import com.zerobase.foodlier.module.recipe.domain.vo.RecipeDetail;
 import com.zerobase.foodlier.module.recipe.domain.vo.RecipeIngredient;
 import com.zerobase.foodlier.module.recipe.domain.vo.RecipeStatistics;
 import com.zerobase.foodlier.module.recipe.domain.vo.Summary;
@@ -137,15 +138,11 @@ public class RecipeServiceImpl implements RecipeService {
      * 작성일자: 2023-09-27
      */
     @Override
-    public ImageUrlDto deleteRecipe(Long id) {
+    public void deleteRecipe(Long id) {
         Recipe recipe = recipeRepository.findById(id)
                 .orElseThrow(() -> new RecipeException(NO_SUCH_RECIPE));
         recipeRepository.deleteById(id);
         recipeSearchRepository.deleteById(recipe.getId());
-        return ImageUrlDto.builder()
-                .mainImageUrl(recipe.getMainImageUrl())
-                .recipeDetailList(recipe.getRecipeDetailList())
-                .build();
     }
 
     /**
@@ -166,6 +163,21 @@ public class RecipeServiceImpl implements RecipeService {
 
         return recipeList;
 
+    }
+
+    /**
+     * 업데이트 시 기존의 이미지 반환
+     */
+    @Override
+    public ImageUrlDto getBeforeImageUrl(Long id) {
+        Recipe recipe = recipeRepository.findById(id)
+                .orElseThrow(() -> new RecipeException(NO_SUCH_RECIPE));
+        return ImageUrlDto.builder()
+                .mainImageUrl(recipe.getMainImageUrl())
+                .cookingOrderImageUrlList(recipe.getRecipeDetailList()
+                        .stream().map(RecipeDetail::getCookingOrderImageUrl)
+                        .collect(Collectors.toList()))
+                .build();
     }
 
 }

--- a/src/test/java/com/zerobase/foodlier/global/recipe/facade/RecipeFacadeTest.java
+++ b/src/test/java/com/zerobase/foodlier/global/recipe/facade/RecipeFacadeTest.java
@@ -285,9 +285,9 @@ class RecipeFacadeTest {
 
         // when
         recipeFacade.updateRecipe(email, recipeDtoRequest, recipeId);
-        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
 
         // then
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(recipeService, times(1)).updateRecipe(recipeDtoRequest, recipeId);
         verify(s3Service, times(3)).deleteImage(captor.capture());
 
@@ -324,43 +324,44 @@ class RecipeFacadeTest {
         assertEquals(NO_PERMISSION, recipeException.getErrorCode());
     }
 
-//    @Test
-//    @DisplayName("꿀조합 게시글 삭제, 삭제 후 이미지 삭제 성공")
-//    void success_delete_recipe() {
-//        //given
-//        String email = "email@email.com";
-//        Long recipeId = 10L;
-//        Long id = 1L;
-//        String mainImageUrl = "https://zb-foodlier.s3.ap-northeast-2.amazonaws.com/img1.jpg";
-//        String cookingOrderImageUrl1 = "https://zb-foodlier.s3.ap-northeast-2.amazonaws.com/img2.jpg";
-//        String cookingOrderImageUrl2 = "https://zb-foodlier.s3.ap-northeast-2.amazonaws.com/img3.jpg";
-//
-//        given(memberService.findByEmail(email)).willReturn(Member.builder()
-//                .id(id)
-//                .build());
-//        given(recipeService.getRecipe(recipeId)).willReturn(Recipe.builder()
-//                .member(Member.builder()
-//                        .id(id)
-//                        .build())
-//                .build());
-//        given(recipeService.deleteRecipe(recipeId))
-//                .willReturn(ImageUrlDto.builder()
-//                        .mainImageUrl(mainImageUrl)
-//                        .recipeDetailList(new ArrayList<>(List.of(
-//                                RecipeDetail.builder()
-//                                        .cookingOrderImageUrl(cookingOrderImageUrl1)
-//                                        .build(),
-//                                RecipeDetail.builder()
-//                                        .cookingOrderImageUrl(cookingOrderImageUrl2)
-//                                        .build())))
-//                        .build());
-//
-//        //when
-//        recipeFacade.deleteRecipe(email, recipeId);
-//
-//        //then
-//        verify(s3Service, times(3)).deleteImage(any());
-//    }
+    @Test
+    @DisplayName("꿀조합 게시글 삭제, 삭제 후 이미지 삭제 성공")
+    void success_delete_recipe() {
+        //given
+        String email = "email@email.com";
+        Long recipeId = 10L;
+        Long id = 1L;
+
+        given(memberService.findByEmail(email)).willReturn(Member.builder()
+                .id(id)
+                .build());
+        given(recipeService.getRecipe(recipeId)).willReturn(Recipe.builder()
+                .member(Member.builder()
+                        .id(id)
+                        .build())
+                .build());
+        given(recipeService.getBeforeImageUrl(recipeId)).willReturn(
+                ImageUrlDto.builder()
+                        .mainImageUrl("old://image.com/image1.jpg")
+                        .cookingOrderImageUrlList(new ArrayList<>(List.of(
+                                "old://image.com/image2.jpg",
+                                "old://image.com/image3.jpg"
+                        )))
+                        .build());
+
+        //when
+        recipeFacade.deleteRecipe(email, recipeId);
+
+        //then
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(recipeService, times(1)).deleteRecipe(recipeId);
+        verify(s3Service, times(3)).deleteImage(captor.capture());
+
+        List<String> captorList = captor.getAllValues();
+        assertEquals("old://image.com/image1.jpg", captorList.get(0));
+        assertEquals("old://image.com/image2.jpg", captorList.get(1));
+        assertEquals("old://image.com/image3.jpg", captorList.get(2));
+    }
 
     @Test
     @DisplayName("꿀조합 게시글 삭제, 삭제 후 이미지 삭제 실패 - 권한없음")

--- a/src/test/java/com/zerobase/foodlier/module/recipe/service/RecipeServiceImplTest.java
+++ b/src/test/java/com/zerobase/foodlier/module/recipe/service/RecipeServiceImplTest.java
@@ -343,13 +343,13 @@ class RecipeServiceImplTest {
                         .build()));
 
         //when
-        ImageUrlDto imageUrlDto = recipeService.deleteRecipe(id);
+        ImageUrlDto imageUrlDto = recipeService.getBeforeImageUrl(id);
+        recipeService.deleteRecipe(id);
 
         //then
         verify(recipeRepository, times(1)).deleteById(id);
 
         assertEquals("image.jpg", imageUrlDto.getMainImageUrl());
-        assertEquals(RecipeDetail.class, imageUrlDto.getRecipeDetailList().get(0).getClass());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- s3이미지 수정로직 오류로 인한 코드 수정
- 테스트코드 작성

## Describe your changes
이전에 s3이미지를 수정하는 로직을 변경하였으나 api테스트결과 기존의 이미지가 수정되는 도중 오류가 발생되었습니다.
```
public void updateRecipe(String email, RecipeDtoRequest recipeDtoRequest, Long id) {
        checkPermission(email, id);
        Recipe recipe = recipeService.getRecipe(id);
        recipeService.updateRecipe(recipeDtoRequest, id);
        deleteRecipeImage(ImageUrlDto.builder()
                .mainImageUrl(recipe.getMainImageUrl())
                .recipeDetailList(recipe.getRecipeDetailList())
                .build());
    }
```
해당 메소드에서 recipe로 이미지값들을 저장한 상태로 recipeService에서 수정을 진행한 후 
deleteRecipeImage를 호출하여 기존의 이미지들을 s3에서 삭제하기를 예상하였으나
updateRecipe를 호출하여 recipe 엔티티가 수정되었기 때문에
mainImageUrl의 정상적인 삭제 이후
recipe와 embaddable인 recipeDetail에서 이미지를 삭제하지 못하는 오류를 발생했습니다.

```
public void updateRecipe(String email, RecipeDtoRequest recipeDtoRequest, Long id) {
        checkPermission(email, id);
        ImageUrlDto imageUrlDto = recipeService.getBeforeImageUrl(id);
        recipeService.updateRecipe(recipeDtoRequest, id);
        deleteRecipeImage(imageUrlDto);
    }
```

해당 부분은 ImageUrlDto객체를 통해 이미지 값들만 recipe엔티티에서 추출하여 영향을 받지 않게 만들었고, 
api테스트를 통해 직접 s3에서 수정되는 것을 확인하였습니다.

추가적으로, 로직이 일부 변경되면서 테스트코드 또한 일부 수정하였습니다.

## Issue number and link
#17 