### PR TITLE
BE - form 요청서 CRUD 작성

### DIFF
--- a/src/main/java/com/zerobase/foodlier/global/refrigerator/controller/RefrigeratorController.java
+++ b/src/main/java/com/zerobase/foodlier/global/refrigerator/controller/RefrigeratorController.java
@@ -3,10 +3,18 @@ package com.zerobase.foodlier.global.refrigerator.controller;
 import com.zerobase.foodlier.common.security.provider.dto.MemberAuthDto;
 import com.zerobase.foodlier.global.refrigerator.facade.RefrigeratorFacade;
 import com.zerobase.foodlier.module.request.service.RequestService;
+import com.zerobase.foodlier.module.requestform.domain.model.RequestForm;
+import com.zerobase.foodlier.module.requestform.dto.RequestFormDetailDto;
+import com.zerobase.foodlier.module.requestform.dto.RequestFormDto;
+import com.zerobase.foodlier.module.requestform.dto.RequestFormResponseDto;
+import com.zerobase.foodlier.module.requestform.service.RequestFormService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -14,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class RefrigeratorController {
     private final RequestService requestService;
     private final RefrigeratorFacade refrigeratorFacade;
+    private final RequestFormService requestFormService;
 
     @PatchMapping("/send?requestId={requestId}&chefMemberId={chefMemberId}")
     public ResponseEntity<String> sendRequest(
@@ -50,5 +59,55 @@ public class RefrigeratorController {
     ) {
         requestService.rejectRequest(memberAuthDto, requestId);
         return ResponseEntity.ok("요청을 거절하였습니다.");
+    }
+
+    @PostMapping
+    public ResponseEntity<String> createRequestForm(
+            @AuthenticationPrincipal MemberAuthDto memberAuthDto,
+            @RequestBody RequestFormDto requestFormDto
+    ) {
+        requestFormService.createRequestForm(memberAuthDto.getId(), requestFormDto);
+        return ResponseEntity.ok("요청이 완료되었습니다.");
+    }
+
+    @GetMapping("/{pageIdx}/{pageSize}")
+    public ResponseEntity<Page<RequestFormResponseDto>> getMyRequestForm(
+            @AuthenticationPrincipal MemberAuthDto memberAuthDto,
+            @PathVariable int pageIdx,
+            @PathVariable int pageSize
+    ) {
+        return ResponseEntity.ok(requestFormService.getMyRequestForm(
+                memberAuthDto.getId(), pageIdx, pageSize));
+    }
+
+    @GetMapping("/{requestFormId}")
+    public ResponseEntity<RequestFormDetailDto> getRequestFormDetail(
+            @AuthenticationPrincipal MemberAuthDto memberAuthDto,
+            @PathVariable Long requestFormId
+    ) {
+        return ResponseEntity.ok(requestFormService.getRequestFormDetail(
+                memberAuthDto.getId(), requestFormId));
+    }
+
+    @PutMapping("{requestFormId}")
+    public ResponseEntity<String> updateRequestForm(
+            @AuthenticationPrincipal MemberAuthDto memberAuthDto,
+            @RequestBody RequestFormDto requestFormDto,
+            @PathVariable Long requestFormId
+    ) {
+        requestFormService.updateRequestForm(
+                memberAuthDto.getId(), requestFormDto, requestFormId);
+        return ResponseEntity.ok("요청서 변경을 완료했습니다.");
+    }
+
+    @DeleteMapping("{requestFormId}")
+    public ResponseEntity<String> deleteRequestForm(
+            @AuthenticationPrincipal MemberAuthDto memberAuthDto,
+            @PathVariable Long requestFormId
+    ) {
+        requestFormService.deleteRequestForm(
+                memberAuthDto.getId(), requestFormId
+        );
+        return ResponseEntity.ok("요청서 삭제를 완료하였습니다.");
     }
 }

--- a/src/main/java/com/zerobase/foodlier/global/refrigerator/controller/RefrigeratorController.java
+++ b/src/main/java/com/zerobase/foodlier/global/refrigerator/controller/RefrigeratorController.java
@@ -79,7 +79,7 @@ public class RefrigeratorController {
             @RequestBody RequestFormDto requestFormDto
     ) {
         requestFormService.createRequestForm(memberAuthDto.getId(), requestFormDto);
-        return ResponseEntity.ok("요청이 완료되었습니다.");
+        return ResponseEntity.ok("요청서 작성이 완료되었습니다.");
     }
 
     @GetMapping("/{pageIdx}/{pageSize}")

--- a/src/main/java/com/zerobase/foodlier/module/recipe/exception/RecipeErrorCode.java
+++ b/src/main/java/com/zerobase/foodlier/module/recipe/exception/RecipeErrorCode.java
@@ -8,6 +8,9 @@ import lombok.RequiredArgsConstructor;
 public enum RecipeErrorCode {
     NO_SUCH_RECIPE("레시피가 없습니다."),
     NO_PERMISSION("레시피 접근 권한이 없습니다."),
+    NOT_PUBLIC_RECIPE("공개되지 않은 레시피입니다."),
+    DELETED_RECIPE("삭제된 레시피입니다."),
+    QUOTATION_CANNOT_BE_TAGGED("견적서는 태그할 수 없습니다."),
     ;
 
     private final String description;

--- a/src/main/java/com/zerobase/foodlier/module/request/domain/vo/Ingredient.java
+++ b/src/main/java/com/zerobase/foodlier/module/request/domain/vo/Ingredient.java
@@ -1,12 +1,18 @@
 package com.zerobase.foodlier.module.request.domain.vo;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 
 @Embeddable
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 public class Ingredient {
     @Column(nullable = false)
     private String ingredientName;

--- a/src/main/java/com/zerobase/foodlier/module/requestform/domain/model/RequestForm.java
+++ b/src/main/java/com/zerobase/foodlier/module/requestform/domain/model/RequestForm.java
@@ -33,7 +33,7 @@ public class RequestForm extends Audit {
     private LocalDateTime expectedAt;
 
     @ElementCollection
-    @CollectionTable(name = "request_from_ingredient")
+    @CollectionTable(name = "request_form_ingredient")
     @Builder.Default
     private List<Ingredient> ingredientList = new ArrayList<>();
 

--- a/src/main/java/com/zerobase/foodlier/module/requestform/domain/model/RequestForm.java
+++ b/src/main/java/com/zerobase/foodlier/module/requestform/domain/model/RequestForm.java
@@ -28,7 +28,7 @@ public class RequestForm extends Audit {
     @Column(nullable = false)
     private String content;
     @Column(nullable = false)
-    private Long expectPrice;
+    private Long expectedPrice;
     @Column(nullable = false)
     private LocalDateTime expectedAt;
 

--- a/src/main/java/com/zerobase/foodlier/module/requestform/dto/RequestFormDetailDto.java
+++ b/src/main/java/com/zerobase/foodlier/module/requestform/dto/RequestFormDetailDto.java
@@ -1,0 +1,22 @@
+package com.zerobase.foodlier.module.requestform.dto;
+
+import com.zerobase.foodlier.module.recipe.domain.model.Recipe;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RequestFormDetailDto {
+    private Long requestId;
+    private String title;
+    private String content;
+    private List<String> ingredientList;
+    private Long expectedPrice;
+    private LocalDateTime expectedAt;
+    private Recipe recipe;
+}

--- a/src/main/java/com/zerobase/foodlier/module/requestform/dto/RequestFormDetailDto.java
+++ b/src/main/java/com/zerobase/foodlier/module/requestform/dto/RequestFormDetailDto.java
@@ -12,7 +12,7 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class RequestFormDetailDto {
-    private Long requestId;
+    private Long requestFormId;
     private String title;
     private String content;
     private List<String> ingredientList;

--- a/src/main/java/com/zerobase/foodlier/module/requestform/dto/RequestFormDto.java
+++ b/src/main/java/com/zerobase/foodlier/module/requestform/dto/RequestFormDto.java
@@ -1,0 +1,20 @@
+package com.zerobase.foodlier.module.requestform.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RequestFormDto {
+    private Long recipeId;
+    private String title;
+    private String content;
+    private Long expectedPrice;
+    private LocalDateTime expectedAt;
+    private List<String> ingredientList;
+}

--- a/src/main/java/com/zerobase/foodlier/module/requestform/dto/RequestFormResponseDto.java
+++ b/src/main/java/com/zerobase/foodlier/module/requestform/dto/RequestFormResponseDto.java
@@ -1,0 +1,23 @@
+package com.zerobase.foodlier.module.requestform.dto;
+
+import com.zerobase.foodlier.module.requestform.domain.model.RequestForm;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RequestFormResponseDto {
+    private Long requestId;
+    private String title;
+    private String content;
+
+    public static RequestFormResponseDto fromEntity(RequestForm requestForm) {
+        return RequestFormResponseDto.builder()
+                .requestId(requestForm.getId())
+                .title(requestForm.getTitle())
+                .content(requestForm.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/zerobase/foodlier/module/requestform/exception/RequestFormErrorCode.java
+++ b/src/main/java/com/zerobase/foodlier/module/requestform/exception/RequestFormErrorCode.java
@@ -6,7 +6,9 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum RequestFormErrorCode {
-    REQUEST_FORM_NOT_FOUND("요청서를 찾을 수 없습니다.");
+    REQUEST_FORM_NOT_FOUND("요청서를 찾을 수 없습니다."),
+    SELECT_REQUEST_FORM_PERMISSION_DENIED("요청서 조회 권한이 없습니다."),
+    ;
 
     private final String description;
 }

--- a/src/main/java/com/zerobase/foodlier/module/requestform/exception/RequestFormErrorCode.java
+++ b/src/main/java/com/zerobase/foodlier/module/requestform/exception/RequestFormErrorCode.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum RequestFormErrorCode {
     REQUEST_FORM_NOT_FOUND("요청서를 찾을 수 없습니다."),
-    SELECT_REQUEST_FORM_PERMISSION_DENIED("요청서 조회 권한이 없습니다."),
+    REQUEST_FORM_PERMISSION_DENIED("요청서 권한이 없습니다."),
     ;
 
     private final String description;

--- a/src/main/java/com/zerobase/foodlier/module/requestform/repository/RequestFormRepository.java
+++ b/src/main/java/com/zerobase/foodlier/module/requestform/repository/RequestFormRepository.java
@@ -1,10 +1,12 @@
 package com.zerobase.foodlier.module.requestform.repository;
 
+import com.zerobase.foodlier.module.member.member.domain.model.Member;
 import com.zerobase.foodlier.module.requestform.domain.model.RequestForm;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RequestFormRepository extends JpaRepository<RequestForm, Long> {
-    Page<RequestForm> findAllByIdOrderByCreatedAtDesc(Long id, PageRequest pageRequest);
+
+    Page<RequestForm> findAllByMemberOrderByCreatedAtDesc(Member member, PageRequest pageRequest);
 }

--- a/src/main/java/com/zerobase/foodlier/module/requestform/repository/RequestFormRepository.java
+++ b/src/main/java/com/zerobase/foodlier/module/requestform/repository/RequestFormRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RequestFormRepository extends JpaRepository<RequestForm, Long> {
-    Page<RequestForm> findAllByIdOrderByDateDesc(Long id, PageRequest pageRequest);
+    Page<RequestForm> findAllByIdOrderByCreatedAtDesc(Long id, PageRequest pageRequest);
 }

--- a/src/main/java/com/zerobase/foodlier/module/requestform/repository/RequestFormRepository.java
+++ b/src/main/java/com/zerobase/foodlier/module/requestform/repository/RequestFormRepository.java
@@ -1,7 +1,10 @@
 package com.zerobase.foodlier.module.requestform.repository;
 
 import com.zerobase.foodlier.module.requestform.domain.model.RequestForm;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RequestFormRepository extends JpaRepository<RequestForm, Long> {
+    Page<RequestForm> findAllByIdOrderByDateDesc(Long id, PageRequest pageRequest);
 }

--- a/src/main/java/com/zerobase/foodlier/module/requestform/service/RequestFormService.java
+++ b/src/main/java/com/zerobase/foodlier/module/requestform/service/RequestFormService.java
@@ -1,4 +1,18 @@
 package com.zerobase.foodlier.module.requestform.service;
 
+import com.zerobase.foodlier.module.requestform.dto.RequestFormDetailDto;
+import com.zerobase.foodlier.module.requestform.dto.RequestFormDto;
+import com.zerobase.foodlier.module.requestform.dto.RequestFormResponseDto;
+import org.springframework.data.domain.Page;
+
 public interface RequestFormService {
+    void createRequestForm(Long id, RequestFormDto requestFormDto);
+
+    Page<RequestFormResponseDto> getMyRequestForm(Long id, int pageIdx, int pageSize);
+
+    RequestFormDetailDto getRequestFormDetail(Long id, Long requestId);
+
+    void updateRequestForm(Long id, RequestFormDto requestFormDto, Long requestFormId);
+
+    void deleteRequestForm(Long id, Long requestFormId);
 }

--- a/src/main/java/com/zerobase/foodlier/module/requestform/service/RequestFormServiceImpl.java
+++ b/src/main/java/com/zerobase/foodlier/module/requestform/service/RequestFormServiceImpl.java
@@ -74,7 +74,7 @@ public class RequestFormServiceImpl implements RequestFormService {
             Long id, int pageIdx, int pageSize) {
         PageRequest pageRequest = PageRequest.of(pageIdx, pageSize);
         Page<RequestForm> requestFormPage = requestFormRepository
-                .findAllByIdOrderByDateDesc(id, pageRequest);
+                .findAllByIdOrderByCreatedAtDesc(id, pageRequest);
         return requestFormPage.map(RequestFormResponseDto::fromEntity);
     }
 

--- a/src/main/java/com/zerobase/foodlier/module/requestform/service/RequestFormServiceImpl.java
+++ b/src/main/java/com/zerobase/foodlier/module/requestform/service/RequestFormServiceImpl.java
@@ -1,0 +1,174 @@
+package com.zerobase.foodlier.module.requestform.service;
+
+import com.zerobase.foodlier.module.member.member.domain.model.Member;
+import com.zerobase.foodlier.module.member.member.exception.MemberException;
+import com.zerobase.foodlier.module.member.member.repository.MemberRepository;
+import com.zerobase.foodlier.module.recipe.domain.model.Recipe;
+import com.zerobase.foodlier.module.recipe.exception.RecipeException;
+import com.zerobase.foodlier.module.recipe.repository.RecipeRepository;
+import com.zerobase.foodlier.module.request.domain.vo.Ingredient;
+import com.zerobase.foodlier.module.requestform.domain.model.RequestForm;
+import com.zerobase.foodlier.module.requestform.dto.RequestFormDetailDto;
+import com.zerobase.foodlier.module.requestform.dto.RequestFormDto;
+import com.zerobase.foodlier.module.requestform.dto.RequestFormResponseDto;
+import com.zerobase.foodlier.module.requestform.exception.RequestFormException;
+import com.zerobase.foodlier.module.requestform.repository.RequestFormRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static com.zerobase.foodlier.module.member.member.exception.MemberErrorCode.MEMBER_NOT_FOUND;
+import static com.zerobase.foodlier.module.recipe.exception.RecipeErrorCode.*;
+import static com.zerobase.foodlier.module.requestform.exception.RequestFormErrorCode.REQUEST_FORM_NOT_FOUND;
+import static com.zerobase.foodlier.module.requestform.exception.RequestFormErrorCode.SELECT_REQUEST_FORM_PERMISSION_DENIED;
+
+@Service
+@RequiredArgsConstructor
+public class RequestFormServiceImpl implements RequestFormService {
+
+    private final RequestFormRepository requestFormRepository;
+    private final RecipeRepository recipeRepository;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 작성일 : 2023-09-29
+     * 작성자 : 황태원
+     * 요청서 작성, 삭제된 레시피, 공개되지 않은 레시피, 견적서를 체크
+     */
+    @Override
+    public void createRequestForm(Long id, RequestFormDto requestFormDto) {
+        Member member = memberRepository.findById(id)
+                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+        Recipe recipe = recipeRepository.findById(requestFormDto.getRecipeId())
+                .orElseThrow(() -> new RecipeException(NO_SUCH_RECIPE));
+
+        checkValidation(recipe);
+
+        requestFormRepository.save(RequestForm.builder()
+                .title(requestFormDto.getTitle())
+                .content(requestFormDto.getContent())
+                .expectedPrice(requestFormDto.getExpectedPrice())
+                .expectedAt(requestFormDto.getExpectedAt())
+                .ingredientList(requestFormDto.getIngredientList()
+                        .stream()
+                        .map(ingredient -> Ingredient.builder()
+                                .ingredientName(ingredient)
+                                .build())
+                        .collect(Collectors.toList()))
+                .member(member)
+                .recipe(recipe)
+                .build());
+    }
+
+    /**
+     * 작성일 : 2023-09-29
+     * 작성자 : 황태원
+     * 작성한 요청서 반환
+     */
+    @Override
+    public Page<RequestFormResponseDto> getMyRequestForm(
+            Long id, int pageIdx, int pageSize) {
+        PageRequest pageRequest = PageRequest.of(pageIdx, pageSize);
+        Page<RequestForm> requestFormPage = requestFormRepository
+                .findAllByIdOrderByDateDesc(id, pageRequest);
+        return requestFormPage.map(RequestFormResponseDto::fromEntity);
+    }
+
+    /**
+     * 작성일 : 2023-09-29
+     * 작성자 : 황태원
+     * 상세 요청서 반환
+     */
+    @Override
+    public RequestFormDetailDto getRequestFormDetail(Long id, Long requestFormId) {
+        RequestForm requestForm = requestFormRepository.findById(requestFormId)
+                .orElseThrow(() -> new RequestFormException(REQUEST_FORM_NOT_FOUND));
+        checkPermission(id, requestForm.getMember().getId());
+        return RequestFormDetailDto.builder()
+                .requestId(requestForm.getId())
+                .title(requestForm.getTitle())
+                .content(requestForm.getContent())
+                .ingredientList(requestForm.getIngredientList().stream()
+                        .map(Ingredient::getIngredientName)
+                        .collect(Collectors.toList()))
+                .expectedPrice(requestForm.getExpectedPrice())
+                .expectedAt(requestForm.getExpectedAt())
+                .recipe(requestForm.getRecipe())
+                .build();
+    }
+
+    /**
+     * 작성일 : 2023-09-29
+     * 작성자 : 황태원
+     * 요청서 업데이트, 태그된 레시피 또한 업데이트, 변경 시 권한 검증
+     */
+    @Override
+    public void updateRequestForm(Long id, RequestFormDto requestFormDto, Long requestFormId) {
+        memberRepository.findById(id)
+                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+        Recipe recipe = recipeRepository.findById(requestFormDto.getRecipeId())
+                .orElseThrow(() -> new RecipeException(NO_SUCH_RECIPE));
+
+        checkValidation(recipe);
+        RequestForm requestForm = requestFormRepository.findById(requestFormId)
+                .orElseThrow(() -> new RequestFormException(REQUEST_FORM_NOT_FOUND));
+        checkPermission(id, requestForm.getMember().getId());
+
+        requestForm.setTitle(requestFormDto.getTitle());
+        requestForm.setContent(requestFormDto.getContent());
+        requestForm.setExpectedPrice(requestFormDto.getExpectedPrice());
+        requestForm.setExpectedAt(requestFormDto.getExpectedAt());
+        requestForm.setIngredientList(requestFormDto.getIngredientList()
+                .stream()
+                .map(ingredient -> Ingredient.builder()
+                        .ingredientName(ingredient)
+                        .build())
+                .collect(Collectors.toList()));
+        requestForm.setRecipe(recipe);
+
+        requestFormRepository.save(requestForm);
+    }
+
+    @Override
+    public void deleteRequestForm(Long id, Long requestFormId) {
+        memberRepository.findById(id)
+                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+        RequestForm requestForm = requestFormRepository.findById(requestFormId)
+                .orElseThrow(() -> new RequestFormException(REQUEST_FORM_NOT_FOUND));
+        checkPermission(id, requestForm.getMember().getId());
+
+        requestFormRepository.deleteById(requestFormId);
+    }
+
+    /**
+     * 작성일 : 2023-09-29
+     * 작성자 : 황태원
+     * 요청서 작성후 해당 요청서에 태그된 레시피가 태그 가능한 레시피인지 검증
+     */
+    private void checkValidation(Recipe recipe) {
+        if (!recipe.getIsPublic()) {
+            throw new RecipeException(NOT_PUBLIC_RECIPE);
+        }
+        if (recipe.getIsDeleted()) {
+            throw new RecipeException(DELETED_RECIPE);
+        }
+        if (recipe.getIsQuotation()) {
+            throw new RecipeException(QUOTATION_CANNOT_BE_TAGGED);
+        }
+    }
+
+    /**
+     * 작성일 : 2023-09-29
+     * 작성자 : 황태원
+     * 요청서 가져오기, 수정, 삭제시 해당 요청서에 대한 권한 검증
+     */
+    private void checkPermission(Long id, Long memberId) {
+        if (!Objects.equals(id, memberId)) {
+            throw new RequestFormException(SELECT_REQUEST_FORM_PERMISSION_DENIED);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
요청서 CRUD 로직을 작성했습니다.

## Describe your changes
작성한 기능은 다음과 같습니다.

* 요청서 작성
* 작성한 요청서 page로 조회
* 요청서 상세조회
* 요청서 수정
* 요청서 삭제

요청서를 작성하여 저장할 때 태그된 레시피가 태그 가능한 레시피인지 검증을 진행합니다.
요청서 작성페이지에서 레시피를 검색할 때 검증이 들어갈 것이라고 예상하지만, 추가로 검증로직을 작성하였습니다.
(검증 대상 - public이 아닌 레시피, 삭제된 레시피(소프트딜리트), 견적서인 경우)

또한 요청서 가져오기, 수정, 삭제를 할 때 요청을 보낸 id와 요청서 작성자의 id가 일치하는지 검증합니다.

## Issue number and link
#65 