### PR TITLE
BE - 요청된 요리사 조회 및 반경 nKm이내 요청되지 않은 요리사 필터 조회

### DIFF
--- a/src/main/java/com/zerobase/foodlier/global/refrigerator/controller/RefrigeratorController.java
+++ b/src/main/java/com/zerobase/foodlier/global/refrigerator/controller/RefrigeratorController.java
@@ -2,6 +2,10 @@ package com.zerobase.foodlier.global.refrigerator.controller;
 
 import com.zerobase.foodlier.common.security.provider.dto.MemberAuthDto;
 import com.zerobase.foodlier.global.refrigerator.facade.RefrigeratorFacade;
+import com.zerobase.foodlier.module.member.chef.dto.AroundChefDto;
+import com.zerobase.foodlier.module.member.chef.dto.RequestedChefDto;
+import com.zerobase.foodlier.module.member.chef.service.ChefMemberService;
+import com.zerobase.foodlier.module.member.chef.type.ChefSearchType;
 import com.zerobase.foodlier.module.request.service.RequestService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -9,12 +13,15 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/refrigerator")
 public class RefrigeratorController {
     private final RequestService requestService;
     private final RefrigeratorFacade refrigeratorFacade;
+    private final ChefMemberService chefMemberService;
 
     @PatchMapping("/send")
     public ResponseEntity<String> sendRequest(
@@ -62,5 +69,30 @@ public class RefrigeratorController {
     ) {
         requestService.rejectRequest(memberAuthDto.getId(), requestId);
         return ResponseEntity.ok("요청을 거절하였습니다.");
+    }
+
+    @GetMapping("/chef/requested/{pageIdx}/{pageSize}")
+    public ResponseEntity<List<RequestedChefDto>> getRequestedChefList(
+            @AuthenticationPrincipal MemberAuthDto memberAuthDto,
+            @PathVariable int pageIdx,
+            @PathVariable int pageSize
+    ){
+        return ResponseEntity.ok(
+                chefMemberService.getRequestedChefList(memberAuthDto.getId(),
+                        pageIdx, pageSize)
+        );
+    }
+
+    @GetMapping("/chef/{pageIdx}/{pageSize}")
+    public ResponseEntity<List<AroundChefDto>> getAroundChefList(
+            @AuthenticationPrincipal MemberAuthDto memberAuthDto,
+            @PathVariable int pageIdx,
+            @PathVariable int pageSize,
+            @RequestParam ChefSearchType type
+    ){
+        return ResponseEntity.ok(
+                chefMemberService.getAroundChefList(memberAuthDto.getId(),
+                        pageIdx, pageSize, type)
+        );
     }
 }

--- a/src/main/java/com/zerobase/foodlier/module/member/chef/dto/AroundChefDto.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/chef/dto/AroundChefDto.java
@@ -14,5 +14,6 @@ public interface AroundChefDto {
 
     //etc
     double getDistance();
+    int getRecipeCount();
 
 }

--- a/src/main/java/com/zerobase/foodlier/module/member/chef/dto/AroundChefDto.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/chef/dto/AroundChefDto.java
@@ -1,0 +1,18 @@
+package com.zerobase.foodlier.module.member.chef.dto;
+
+public interface AroundChefDto {
+
+    //chefMember
+    Long getChefId();
+    String getIntroduce();
+    double getStarAvg();
+    int getReviewCount();
+
+    //member
+    String getProfileUrl();
+    String getNickname();
+
+    //etc
+    double getDistance();
+
+}

--- a/src/main/java/com/zerobase/foodlier/module/member/chef/dto/RequestedChefDto.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/chef/dto/RequestedChefDto.java
@@ -14,6 +14,7 @@ public interface RequestedChefDto {
 
     //etc
     double getDistance();
+    int getRecipeCount();
 
     //request
     Long getRequestId();

--- a/src/main/java/com/zerobase/foodlier/module/member/chef/dto/RequestedChefDto.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/chef/dto/RequestedChefDto.java
@@ -1,0 +1,23 @@
+package com.zerobase.foodlier.module.member.chef.dto;
+
+public interface RequestedChefDto {
+
+    //chefMember
+    Long getChefId();
+    String getIntroduce();
+    double getStarAvg();
+    int getReviewCount();
+
+    //member
+    String getProfileUrl();
+    String getNickname();
+
+    //etc
+    double getDistance();
+
+    //request
+    Long getRequestId();
+    int getIsQuotation();
+    Long getQuotationId();
+
+}

--- a/src/main/java/com/zerobase/foodlier/module/member/chef/repository/ChefMemberRepository.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/chef/repository/ChefMemberRepository.java
@@ -1,10 +1,67 @@
 package com.zerobase.foodlier.module.member.chef.repository;
 
 import com.zerobase.foodlier.module.member.chef.domain.model.ChefMember;
+import com.zerobase.foodlier.module.member.chef.dto.AroundChefDto;
+import com.zerobase.foodlier.module.member.chef.dto.RequestedChefDto;
 import com.zerobase.foodlier.module.member.member.domain.model.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ChefMemberRepository extends JpaRepository<ChefMember, Long> {
     boolean existsByMember(Member member);
+
+    @Query(
+            value = "SELECT c.id as chefId, c.introduce as introduce, c.star_avg as starAvg,\n" +
+                    "c.review_count as reviewCount, m.profile_url as profileUrl, m.nickname as nickname,\n" +
+                    "ROUND(st_distance_sphere(point(m.lnt, m.lat), point(rm.lnt, rm.lat))/1000, 2) as distance,\n" +
+                    "rq.id as requestId, IFNULL(rp.is_quotation, false) as isQuotation, rp.id as quotationId\n" +
+                    "FROM member rm\n" +
+                    "RIGHT JOIN cook_request rq ON rq.member_id = rm.id\n" +
+                    "LEFT JOIN chef_member c ON c.id = rq.chef_member_id\n" +
+                    "JOIN member m ON m.id = c.member_id\n" +
+                    "LEFT JOIN recipe rp ON rp.id = rq.recipe_id\n" +
+                    "where rm.id = :requester AND rq.is_paid = false AND rq.dm_room_id is null\n" +
+                    "limit :start, :end"
+            ,nativeQuery = true
+    )
+    List<RequestedChefDto> findRequestedChef(
+        @Param("requester") Long memberId,
+        @Param("start") int start,
+        @Param("end") int end
+    );
+
+    @Query(
+            value = "SELECT c.id as chefId, c.introduce as introduce, c.star_avg as starAvg,\n" +
+                    "c.review_count as reviewCount, m.profile_url as profileUrl, m.nickname as nickname,\n" +
+                    "ROUND(st_distance_sphere(point(m.lnt, m.lat), point(:lnt, :lat))/1000, 2) as distance\n" +
+                    "FROM chef_member c\n" +
+                    "LEFT JOIN member m ON m.chef_member_id = c.id\n" +
+                    "WHERE m.id <> :requester\n" +
+                    "AND ST_CONTAINS(\n" +
+                    "    ST_BUFFER(POINT(:lat, :lnt), :distance),\n" +
+                    "    POINT(m.lat, m.lnt))\n" +
+                    "AND c.id NOT IN\n" +
+                    "(\n" +
+                    "\tSELECT c.id\n" +
+                    "\tFROM member rm\n" +
+                    "\tRIGHT JOIN cook_request rq ON rq.member_id = rm.id\n" +
+                    "\tLEFT JOIN chef_member c ON c.id = rq.chef_member_id\n" +
+                    "\twhere rm.id = :requester AND rq.is_paid = false AND rq.dm_room_id is null\n" +
+                    ")\n" +
+                    "ORDER BY distance ASC\n" +
+                    "LIMIT :start, :end",
+            nativeQuery = true
+    )
+    List<AroundChefDto> findAroundChef(
+            @Param("requester") Long memberId,
+            @Param("lat") double lat,
+            @Param("lnt") double lnt,
+            @Param("distance") double distance,
+            @Param("start") int start,
+            @Param("end") int end
+    );
 
 }

--- a/src/main/java/com/zerobase/foodlier/module/member/chef/repository/ChefMemberRepository.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/chef/repository/ChefMemberRepository.java
@@ -29,6 +29,7 @@ public interface ChefMemberRepository extends JpaRepository<ChefMember, Long> {
                     "    FROM chef_member c\n" +
                     "    JOIN member m ON m.chef_member_id = c.id\n" +
                     "    JOIN recipe r ON r.member_id = m.id\n" +
+                    "    WHERE r.is_quotation = false and r.is_deleted = false and r.is_public = true\n" +
                     "    GROUP BY c.id\n" +
                     ") as rc ON rc.chef_member_id = c.id\n" +
                     "WHERE rm.id = :requester\n" +
@@ -44,7 +45,7 @@ public interface ChefMemberRepository extends JpaRepository<ChefMember, Long> {
     String baseAroundSearchQuery = "SELECT c.id as chefId, c.introduce as introduce, c.star_avg as starAvg,\n" +
             "c.review_count as reviewCount, m.profile_url as profileUrl, m.nickname as nickname,\n" +
             "ROUND(st_distance_sphere(point(m.lnt, m.lat), point(:lnt, :lat))/1000, 2) as distance,\n" +
-            "rc.recipeCount\n" +
+            "rc.recipeCount as recipeCount\n" +
             "FROM chef_member c\n" +
             "JOIN member m ON m.chef_member_id = c.id\n" +
             "JOIN\n" +
@@ -53,6 +54,7 @@ public interface ChefMemberRepository extends JpaRepository<ChefMember, Long> {
             "    FROM chef_member c\n" +
             "    JOIN member m ON m.chef_member_id = c.id\n" +
             "    JOIN recipe r ON r.member_id = m.id\n" +
+            "    WHERE r.is_quotation = false and r.is_deleted = false and r.is_public = true\n" +
             "    GROUP BY c.id\n" +
             ") as rc ON rc.chef_member_id = c.id\n" +
             "WHERE m.id <> :requester AND m.is_deleted = false\n" +

--- a/src/main/java/com/zerobase/foodlier/module/member/chef/service/ChefMemberService.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/chef/service/ChefMemberService.java
@@ -3,6 +3,7 @@ package com.zerobase.foodlier.module.member.chef.service;
 import com.zerobase.foodlier.module.member.chef.dto.AroundChefDto;
 import com.zerobase.foodlier.module.member.chef.dto.ChefIntroduceForm;
 import com.zerobase.foodlier.module.member.chef.dto.RequestedChefDto;
+import com.zerobase.foodlier.module.member.chef.type.ChefSearchType;
 
 import java.util.List;
 
@@ -14,5 +15,5 @@ public interface ChefMemberService {
                                                 int pageIdx, int pageSize);
 
     List<AroundChefDto> getAroundChefList(Long memberId,
-                                          int pageIdx, int pageSize);
+                                          int pageIdx, int pageSize, ChefSearchType type);
 }

--- a/src/main/java/com/zerobase/foodlier/module/member/chef/service/ChefMemberService.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/chef/service/ChefMemberService.java
@@ -1,8 +1,18 @@
 package com.zerobase.foodlier.module.member.chef.service;
 
+import com.zerobase.foodlier.module.member.chef.dto.AroundChefDto;
 import com.zerobase.foodlier.module.member.chef.dto.ChefIntroduceForm;
+import com.zerobase.foodlier.module.member.chef.dto.RequestedChefDto;
+
+import java.util.List;
 
 public interface ChefMemberService {
     void registerChef(Long memberId, ChefIntroduceForm chefIntroduceForm);
     void updateChefIntroduce(Long memberId, ChefIntroduceForm chefIntroduceForm);
+
+    List<RequestedChefDto> getRequestedChefList(Long memberId,
+                                                int pageIdx, int pageSize);
+
+    List<AroundChefDto> getAroundChefList(Long memberId,
+                                          int pageIdx, int pageSize);
 }

--- a/src/main/java/com/zerobase/foodlier/module/member/chef/service/ChefMemberServiceImpl.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/chef/service/ChefMemberServiceImpl.java
@@ -6,6 +6,7 @@ import com.zerobase.foodlier.module.member.chef.dto.ChefIntroduceForm;
 import com.zerobase.foodlier.module.member.chef.dto.RequestedChefDto;
 import com.zerobase.foodlier.module.member.chef.exception.ChefMemberException;
 import com.zerobase.foodlier.module.member.chef.repository.ChefMemberRepository;
+import com.zerobase.foodlier.module.member.chef.type.ChefSearchType;
 import com.zerobase.foodlier.module.member.chef.type.GradeType;
 import com.zerobase.foodlier.module.member.member.domain.model.Member;
 import com.zerobase.foodlier.module.member.member.domain.vo.Address;
@@ -27,7 +28,7 @@ import static com.zerobase.foodlier.module.member.chef.exception.ChefMemberError
 @RequiredArgsConstructor
 public class ChefMemberServiceImpl implements ChefMemberService{
 
-    private static final double AROUND_DISTANCE = 0.01;
+    private static final double AROUND_DISTANCE = 0.012;
     private static final int MIN_RECIPES_FOR_CHEF = 3;
     private final ChefMemberRepository chefMemberRepository;
     private final MemberRepository memberRepository;
@@ -87,11 +88,25 @@ public class ChefMemberServiceImpl implements ChefMemberService{
      *  작성자 : 전현서
      *  작성일 : 2023-09-29
      *  반경 1km내의 요리사 리스트를 페이징하여 반환
+     *  type이 지정되지 않은 경우는 기본적으로 가까운 거리순
      */
     public List<AroundChefDto> getAroundChefList(Long memberId,
-                                                  int pageIdx, int pageSize){
+                                                 int pageIdx, int pageSize,
+                                                 ChefSearchType type){
         Address address = getMember(memberId).getAddress();
-        return chefMemberRepository.findAroundChef(memberId, address.getLat(),
+
+        switch (type){
+            case STAR:
+                return chefMemberRepository.findAroundChefOrderByStar(memberId, address.getLat(),
+                        address.getLnt(), AROUND_DISTANCE, pageIdx * pageSize, pageSize);
+            case REVIEW:
+                return chefMemberRepository.findAroundChefOrderByReview(memberId, address.getLat(),
+                        address.getLnt(), AROUND_DISTANCE, pageIdx * pageSize, pageSize);
+            case RECIPE:
+                break;
+        }
+
+        return chefMemberRepository.findAroundChefOrderByDistance(memberId, address.getLat(),
                 address.getLnt(), AROUND_DISTANCE, pageIdx * pageSize, pageSize);
     }
 

--- a/src/main/java/com/zerobase/foodlier/module/member/chef/service/ChefMemberServiceImpl.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/chef/service/ChefMemberServiceImpl.java
@@ -103,7 +103,8 @@ public class ChefMemberServiceImpl implements ChefMemberService{
                 return chefMemberRepository.findAroundChefOrderByReview(memberId, address.getLat(),
                         address.getLnt(), AROUND_DISTANCE, pageIdx * pageSize, pageSize);
             case RECIPE:
-                break;
+                return chefMemberRepository.findAroundChefOrderByRecipeCount(memberId, address.getLat(),
+                        address.getLnt(), AROUND_DISTANCE, pageIdx * pageSize, pageSize);
         }
 
         return chefMemberRepository.findAroundChefOrderByDistance(memberId, address.getLat(),

--- a/src/main/java/com/zerobase/foodlier/module/member/chef/service/ChefMemberServiceImpl.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/chef/service/ChefMemberServiceImpl.java
@@ -1,11 +1,14 @@
 package com.zerobase.foodlier.module.member.chef.service;
 
 import com.zerobase.foodlier.module.member.chef.domain.model.ChefMember;
+import com.zerobase.foodlier.module.member.chef.dto.AroundChefDto;
 import com.zerobase.foodlier.module.member.chef.dto.ChefIntroduceForm;
+import com.zerobase.foodlier.module.member.chef.dto.RequestedChefDto;
 import com.zerobase.foodlier.module.member.chef.exception.ChefMemberException;
 import com.zerobase.foodlier.module.member.chef.repository.ChefMemberRepository;
 import com.zerobase.foodlier.module.member.chef.type.GradeType;
 import com.zerobase.foodlier.module.member.member.domain.model.Member;
+import com.zerobase.foodlier.module.member.member.domain.vo.Address;
 import com.zerobase.foodlier.module.member.member.exception.MemberErrorCode;
 import com.zerobase.foodlier.module.member.member.exception.MemberException;
 import com.zerobase.foodlier.module.member.member.repository.MemberRepository;
@@ -15,12 +18,15 @@ import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 
+import java.util.List;
+
 import static com.zerobase.foodlier.module.member.chef.exception.ChefMemberErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
 public class ChefMemberServiceImpl implements ChefMemberService{
 
+    private static final double AROUND_DISTANCE = 0.01;
     private static final int MIN_RECIPES_FOR_CHEF = 3;
     private final ChefMemberRepository chefMemberRepository;
     private final MemberRepository memberRepository;
@@ -63,6 +69,28 @@ public class ChefMemberServiceImpl implements ChefMemberService{
         ChefMember chefMember = member.getChefMember();
         chefMember.setIntroduce(chefIntroduceForm.getIntroduce());
         chefMemberRepository.save(chefMember);
+    }
+
+    /**
+     *  작성자 : 전현서
+     *  작성일 : 2023-09-29
+     *  요청된 요리사의 정보를 가져옴.
+     */
+    public List<RequestedChefDto> getRequestedChefList(Long memberId,
+                                                   int pageIdx, int pageSize){
+        return chefMemberRepository.findRequestedChef(memberId, pageIdx * pageSize, pageSize);
+    }
+
+    /**
+     *  작성자 : 전현서
+     *  작성일 : 2023-09-29
+     *  반경 1km내의 요리사 리스트를 페이징하여 반환
+     */
+    public List<AroundChefDto> getAroundChefList(Long memberId,
+                                                  int pageIdx, int pageSize){
+        Address address = getMember(memberId).getAddress();
+        return chefMemberRepository.findAroundChef(memberId, address.getLat(),
+                address.getLnt(), AROUND_DISTANCE, pageIdx * pageSize, pageSize);
     }
 
     private Member getMember(Long memberId){

--- a/src/main/java/com/zerobase/foodlier/module/member/chef/type/ChefSearchType.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/chef/type/ChefSearchType.java
@@ -1,0 +1,5 @@
+package com.zerobase.foodlier.module.member.chef.type;
+
+public enum ChefSearchType {
+    DISTANCE, REVIEW, RECIPE, STAR
+}


### PR DESCRIPTION
## Summary
- NativeQuery를 사용하여, 요청된 요리사를 조회하는 기능과
반경 nkm 이내의 요청되지 않은 요리사를 필터를 걸어 조회하는 기능을 구현하였음

## Describe your changes
- 거리에 관한 함수를 사용하기 위해, JPQL이 아닌 MySQL의 NativeQuery를 직접 사용하여 구현하였습니다.

## 반경 1km 이내 요리사들을 조회하는 쿼리
```MYSQL
-- 반경 1km 이내 요청되지 않은 요리사 조회하는 쿼리
SELECT c.id as chefId, c.introduce as introduce, c.star_avg as starAvg,
c.review_count as reviewCount, m.profile_url as profileUrl, m.nickname as nickname,
ROUND(st_distance_sphere(point(m.lnt, m.lat), point(127.1, 37.1))/1000, 2) as distance,
rc.recipeCount as recipeCount
FROM chef_member c
JOIN member m ON m.chef_member_id = c.id
JOIN
(
    SELECT c.id as chef_member_id, COUNT(r.id) as recipeCount
    FROM chef_member c
    JOIN member m ON m.chef_member_id = c.id
    JOIN recipe r ON r.member_id = m.id
    WHERE r.is_quotation = false and r.is_deleted = false and r.is_public = true
    GROUP BY c.id
) as rc ON rc.chef_member_id = c.id
WHERE m.id <> 2 AND m.is_deleted = false
AND ST_CONTAINS(
    ST_BUFFER(POINT(37.1, 127.1), 0.01),
    POINT(m.lat, m.lnt))
AND c.id NOT IN 
(
    SELECT c.id
    FROM member rm
    JOIN cook_request rq ON rq.member_id = rm.id AND rq.is_paid = false AND rq.dm_room_id is null
    JOIN chef_member c ON c.id = rq.chef_member_id
    where rm.id = 2
)
ORDER BY distance ASC
LIMIT 0, 10;
```
- 기본적으로 chef_member 테이블을 가져옵니다.
- member 테이블과 Inner Join하여 member테이블의 정보를 가져옵니다.
- 서브쿼리를 사용하여, 각각의 chef_member에 대한 recipeCount를 가져옵니다.
- 이 때, recipeCount는 견적서가 아니고, 삭제되지 않았고, 공개된 recipe의 count만 가져옵니다.
- 요청자가 요리사일 수도 있기에, 본인인 경우를 where절로 제한하고, 탈퇴한 요리사도 제외합니다.
- ST_CONTAINS와 ST_BUFFER를 사용하여, 반경 1km안으로 존재하는지의 여부를 검증합니다.
- 다시 서브쿼리를 사용하여, 이미 요청한 요리사인지 판별합니다.
- 마지막으로 정렬과, 페이징처리를 수행합니다.


## 요청한 요리사를 조회하는 쿼리
```MYSQL
-- 요청한 요리사 조회하는 쿼리
SELECT c.id as chefId, c.introduce as introduce, c.star_avg as starAvg,
c.review_count as reviewCount, m.profile_url as profileUrl, m.nickname as nickname,
ROUND(st_distance_sphere(point(m.lnt, m.lat), point(rm.lnt, rm.lat))/1000, 2) as distance,
rq.id as requestId, IFNULL(rp.is_quotation, false) as isQuotation, rp.id as quotationId, rc.recipeCount as recipeCount
FROM member rm
JOIN cook_request rq ON rq.member_id = rm.id AND rq.is_paid = false AND rq.dm_room_id is null
JOIN chef_member c ON c.id = rq.chef_member_id
JOIN member m ON m.id = c.member_id AND m.is_deleted = false
LEFT JOIN recipe rp ON rp.id = rq.recipe_id
JOIN
(
    SELECT c.id as chef_member_id, COUNT(r.id) as recipeCount
    FROM chef_member c
    JOIN member m ON m.chef_member_id = c.id
    JOIN recipe r ON r.member_id = m.id
    GROUP BY c.id
) as rc ON rc.chef_member_id = c.id
WHERE rm.id = 2
limit 0, 10;
```

- 요청자를 기준으로 요청데이터를 알아와야하므로 우선적으로 Member 테이블을 가져옵니다.
- cook_request 테이블을 조회하여, Member가 요청한 값을 Join합니다. 이 때, 결제되지 않았고, dm 방이 개설되지 않은 request들만 추출하여 Join합니다.
- 조인된 request와 chef_member를 조인하여, 요청한 chef_member 정보를 가져옵니다.
- 또한, chef_member의 회원정보를 가져와야하므로, Member테이블과 조인시켜줍니다. 이 때, 탈퇴된 Member라고 판별되면 제외시켜줍니다.
- 어떤 레시피를 태깅했거나, 어떤 견적서가 태깅됬는지를 확인하기 위해서, recipe 테이블을 조인합니다. 이 때, recipe테이블은 견적서가 도착하지 않으면 비어있기 때문에, LEFT JOIN을 수행하여, 레코드가 누락되는 것을 방지합니다.
- 이후의 서브쿼리 조인은 chef_member마다 해당되는 recipeCount를 가져옵니다.
- 이후에, 본인이 요청한 것에 대해 필터링을 수행해주고,
- 마지막으로 페이징 처리하여 마무리합니다.

## Issue number and link
#62
