### PR TITLE
BE - 요청/주변 요리사 조회하기 누락된 값 추가 [!HOTFIX]

### DIFF
--- a/src/main/java/com/zerobase/foodlier/module/member/chef/dto/AroundChefDto.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/chef/dto/AroundChefDto.java
@@ -11,6 +11,8 @@ public interface AroundChefDto {
     //member
     String getProfileUrl();
     String getNickname();
+    double getLat();
+    double getLnt();
 
     //etc
     double getDistance();

--- a/src/main/java/com/zerobase/foodlier/module/member/chef/dto/RequestedChefDto.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/chef/dto/RequestedChefDto.java
@@ -11,6 +11,8 @@ public interface RequestedChefDto {
     //member
     String getProfileUrl();
     String getNickname();
+    double getLat();
+    double getLnt();
 
     //etc
     double getDistance();

--- a/src/main/java/com/zerobase/foodlier/module/member/chef/repository/ChefMemberRepository.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/chef/repository/ChefMemberRepository.java
@@ -17,7 +17,8 @@ public interface ChefMemberRepository extends JpaRepository<ChefMember, Long> {
             value = "SELECT c.id as chefId, c.introduce as introduce, c.star_avg as starAvg,\n" +
                     "c.review_count as reviewCount, m.profile_url as profileUrl, m.nickname as nickname,\n" +
                     "ROUND(st_distance_sphere(point(m.lnt, m.lat), point(rm.lnt, rm.lat))/1000, 2) as distance,\n" +
-                    "rq.id as requestId, IFNULL(rp.is_quotation, false) as isQuotation, rp.id as quotationId, rc.recipeCount as recipeCount\n" +
+                    "rq.id as requestId, IFNULL(rp.is_quotation, false) as isQuotation, rp.id as quotationId, rc.recipeCount as recipeCount,\n" +
+                    "m.lat as lat, m.lnt as lnt\n" +
                     "FROM member rm\n" +
                     "JOIN cook_request rq ON rq.member_id = rm.id AND rq.is_paid = false AND rq.dm_room_id is null\n" +
                     "JOIN chef_member c ON c.id = rq.chef_member_id\n" +
@@ -45,7 +46,7 @@ public interface ChefMemberRepository extends JpaRepository<ChefMember, Long> {
     String baseAroundSearchQuery = "SELECT c.id as chefId, c.introduce as introduce, c.star_avg as starAvg,\n" +
             "c.review_count as reviewCount, m.profile_url as profileUrl, m.nickname as nickname,\n" +
             "ROUND(st_distance_sphere(point(m.lnt, m.lat), point(:lnt, :lat))/1000, 2) as distance,\n" +
-            "rc.recipeCount as recipeCount\n" +
+            "rc.recipeCount as recipeCount, m.lat as lat, m.lnt as lnt\n" +
             "FROM chef_member c\n" +
             "JOIN member m ON m.chef_member_id = c.id\n" +
             "JOIN\n" +

--- a/src/test/java/com/zerobase/foodlier/module/member/chef/service/ChefMemberServiceImplTest.java
+++ b/src/test/java/com/zerobase/foodlier/module/member/chef/service/ChefMemberServiceImplTest.java
@@ -277,6 +277,16 @@ class ChefMemberServiceImplTest {
                     }
 
                     @Override
+                    public double getLat() {
+                        return 37.1;
+                    }
+
+                    @Override
+                    public double getLnt() {
+                        return 127.1;
+                    }
+
+                    @Override
                     public double getDistance() {
                         return 1.12;
                     }
@@ -320,6 +330,8 @@ class ChefMemberServiceImplTest {
                 () -> assertEquals(chefList.get(0).getProfileUrl(), responseChefList.get(0).getProfileUrl()),
                 () -> assertEquals(chefList.get(0).getNickname(), responseChefList.get(0).getNickname()),
                 () -> assertEquals(chefList.get(0).getDistance(), responseChefList.get(0).getDistance()),
+                () -> assertEquals(chefList.get(0).getLat(), responseChefList.get(0).getLat()),
+                () -> assertEquals(chefList.get(0).getLnt(), responseChefList.get(0).getLnt()),
                 () -> assertEquals(chefList.get(0).getRecipeCount(), responseChefList.get(0).getRecipeCount()),
                 () -> assertEquals(chefList.get(0).getRequestId(), responseChefList.get(0).getRequestId()),
                 () -> assertEquals(chefList.get(0).getIsQuotation(), responseChefList.get(0).getIsQuotation()),
@@ -368,6 +380,8 @@ class ChefMemberServiceImplTest {
                 () -> assertEquals(chef2.getReviewCount(), response.get(0).getReviewCount()),
                 () -> assertEquals(chef2.getProfileUrl(), response.get(0).getProfileUrl()),
                 () -> assertEquals(chef2.getDistance(), response.get(0).getDistance()),
+                () -> assertEquals(chef2.getLat(), response.get(0).getLat()),
+                () -> assertEquals(chef2.getLnt(), response.get(0).getLnt()),
                 () -> assertEquals(chef2.getNickname(), response.get(0).getNickname()),
                 () -> assertEquals(chef2.getRecipeCount(), response.get(0).getRecipeCount()),
 
@@ -377,6 +391,8 @@ class ChefMemberServiceImplTest {
                 () -> assertEquals(chef1.getReviewCount(), response.get(1).getReviewCount()),
                 () -> assertEquals(chef1.getProfileUrl(), response.get(1).getProfileUrl()),
                 () -> assertEquals(chef1.getDistance(), response.get(1).getDistance()),
+                () -> assertEquals(chef1.getLat(), response.get(1).getLat()),
+                () -> assertEquals(chef1.getLnt(), response.get(1).getLnt()),
                 () -> assertEquals(chef1.getNickname(), response.get(1).getNickname()),
                 () -> assertEquals(chef1.getRecipeCount(), response.get(1).getRecipeCount())
         );
@@ -422,6 +438,8 @@ class ChefMemberServiceImplTest {
                 () -> assertEquals(chef1.getReviewCount(), response.get(0).getReviewCount()),
                 () -> assertEquals(chef1.getProfileUrl(), response.get(0).getProfileUrl()),
                 () -> assertEquals(chef1.getDistance(), response.get(0).getDistance()),
+                () -> assertEquals(chef1.getLat(), response.get(0).getLat()),
+                () -> assertEquals(chef1.getLnt(), response.get(0).getLnt()),
                 () -> assertEquals(chef1.getNickname(), response.get(0).getNickname()),
                 () -> assertEquals(chef1.getRecipeCount(), response.get(0).getRecipeCount()),
 
@@ -431,6 +449,8 @@ class ChefMemberServiceImplTest {
                 () -> assertEquals(chef2.getReviewCount(), response.get(1).getReviewCount()),
                 () -> assertEquals(chef2.getProfileUrl(), response.get(1).getProfileUrl()),
                 () -> assertEquals(chef2.getDistance(), response.get(1).getDistance()),
+                () -> assertEquals(chef2.getLat(), response.get(1).getLat()),
+                () -> assertEquals(chef2.getLnt(), response.get(1).getLnt()),
                 () -> assertEquals(chef2.getNickname(), response.get(1).getNickname()),
                 () -> assertEquals(chef2.getRecipeCount(), response.get(1).getRecipeCount())
         );
@@ -476,6 +496,8 @@ class ChefMemberServiceImplTest {
                 () -> assertEquals(chef1.getReviewCount(), response.get(0).getReviewCount()),
                 () -> assertEquals(chef1.getProfileUrl(), response.get(0).getProfileUrl()),
                 () -> assertEquals(chef1.getDistance(), response.get(0).getDistance()),
+                () -> assertEquals(chef1.getLat(), response.get(0).getLat()),
+                () -> assertEquals(chef1.getLnt(), response.get(0).getLnt()),
                 () -> assertEquals(chef1.getNickname(), response.get(0).getNickname()),
                 () -> assertEquals(chef1.getRecipeCount(), response.get(0).getRecipeCount()),
 
@@ -485,6 +507,8 @@ class ChefMemberServiceImplTest {
                 () -> assertEquals(chef2.getReviewCount(), response.get(1).getReviewCount()),
                 () -> assertEquals(chef2.getProfileUrl(), response.get(1).getProfileUrl()),
                 () -> assertEquals(chef2.getDistance(), response.get(1).getDistance()),
+                () -> assertEquals(chef2.getLat(), response.get(1).getLat()),
+                () -> assertEquals(chef2.getLnt(), response.get(1).getLnt()),
                 () -> assertEquals(chef2.getNickname(), response.get(1).getNickname()),
                 () -> assertEquals(chef2.getRecipeCount(), response.get(1).getRecipeCount())
         );
@@ -530,6 +554,8 @@ class ChefMemberServiceImplTest {
                 () -> assertEquals(chef2.getReviewCount(), response.get(0).getReviewCount()),
                 () -> assertEquals(chef2.getProfileUrl(), response.get(0).getProfileUrl()),
                 () -> assertEquals(chef2.getDistance(), response.get(0).getDistance()),
+                () -> assertEquals(chef2.getLat(), response.get(0).getLat()),
+                () -> assertEquals(chef2.getLnt(), response.get(0).getLnt()),
                 () -> assertEquals(chef2.getNickname(), response.get(0).getNickname()),
                 () -> assertEquals(chef2.getRecipeCount(), response.get(0).getRecipeCount()),
 
@@ -539,6 +565,8 @@ class ChefMemberServiceImplTest {
                 () -> assertEquals(chef1.getReviewCount(), response.get(1).getReviewCount()),
                 () -> assertEquals(chef1.getProfileUrl(), response.get(1).getProfileUrl()),
                 () -> assertEquals(chef1.getDistance(), response.get(1).getDistance()),
+                () -> assertEquals(chef1.getLat(), response.get(1).getLat()),
+                () -> assertEquals(chef1.getLnt(), response.get(1).getLnt()),
                 () -> assertEquals(chef1.getNickname(), response.get(1).getNickname()),
                 () -> assertEquals(chef1.getRecipeCount(), response.get(1).getRecipeCount())
         );
@@ -592,6 +620,16 @@ class ChefMemberServiceImplTest {
             }
 
             @Override
+            public double getLat() {
+                return 37.1;
+            }
+
+            @Override
+            public double getLnt() {
+                return 127.1;
+            }
+
+            @Override
             public double getDistance() {
                 return 1.1;
             }
@@ -633,6 +671,16 @@ class ChefMemberServiceImplTest {
             @Override
             public String getNickname() {
                 return "chef2";
+            }
+
+            @Override
+            public double getLat() {
+                return 37.2;
+            }
+
+            @Override
+            public double getLnt() {
+                return 127.2;
             }
 
             @Override


### PR DESCRIPTION
## Summary
- 요청/주변 요리사를 조회할 때, 위도/경도가 누락되어 추가함.

## Describe your changes
- AroundChefDto, RequestedChefDto에 각각 위도, 경도필드를 추가함.
- NativeQuery에서 lat, lnt를 추가적으로 받도록 수정함.
- 관련된 Test코드 수정됨.

## Issue number and link
#109
