### PR TITLE
BE - 요청서 상세보기 반환값 수정 및 관련 테스트코드 수정

### DIFF
--- a/src/main/java/com/zerobase/foodlier/module/requestform/dto/RequestFormDetailDto.java
+++ b/src/main/java/com/zerobase/foodlier/module/requestform/dto/RequestFormDetailDto.java
@@ -1,5 +1,6 @@
 package com.zerobase.foodlier.module.requestform.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.zerobase.foodlier.module.recipe.domain.model.Recipe;
 import lombok.*;
 
@@ -13,11 +14,15 @@ import java.util.List;
 @Builder
 public class RequestFormDetailDto {
     private Long requestFormId;
+    private String requesterNickname;
     private String title;
     private String content;
     private List<String> ingredientList;
     private Long expectedPrice;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime expectedAt;
+    private String address;
+    private String addressDetail;
     private String mainImageUrl;
     private String recipeTitle;
     private String recipeContent;

--- a/src/main/java/com/zerobase/foodlier/module/requestform/service/RequestFormServiceImpl.java
+++ b/src/main/java/com/zerobase/foodlier/module/requestform/service/RequestFormServiceImpl.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -41,6 +42,7 @@ public class RequestFormServiceImpl implements RequestFormService {
      * 요청서 작성, 삭제된 레시피, 공개되지 않은 레시피, 견적서를 체크
      */
     @Override
+    @Transactional
     public void createRequestForm(Long id, RequestFormDto requestFormDto) {
         Member member = memberRepository.findById(id)
                 .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
@@ -121,6 +123,7 @@ public class RequestFormServiceImpl implements RequestFormService {
      * 요청서 업데이트, 태그된 레시피 또한 업데이트, 변경 시 권한 검증
      */
     @Override
+    @Transactional
     public void updateRequestForm(Long id, RequestFormDto requestFormDto, Long requestFormId) {
         memberRepository.findById(id)
                 .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
@@ -158,6 +161,7 @@ public class RequestFormServiceImpl implements RequestFormService {
      * 요청서 삭제, 삭제 시 권한 검증
      */
     @Override
+    @Transactional
     public void deleteRequestForm(Long id, Long requestFormId) {
         memberRepository.findById(id)
                 .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));

--- a/src/main/java/com/zerobase/foodlier/module/requestform/service/RequestFormServiceImpl.java
+++ b/src/main/java/com/zerobase/foodlier/module/requestform/service/RequestFormServiceImpl.java
@@ -96,6 +96,7 @@ public class RequestFormServiceImpl implements RequestFormService {
         checkPermission(id, requestForm.getMember().getId());
         return RequestFormDetailDto.builder()
                 .requestFormId(requestForm.getId())
+                .requesterNickname(requestForm.getMember().getNickname())
                 .title(requestForm.getTitle())
                 .content(requestForm.getContent())
                 .ingredientList(requestForm.getIngredientList().stream()
@@ -103,6 +104,8 @@ public class RequestFormServiceImpl implements RequestFormService {
                         .collect(Collectors.toList()))
                 .expectedPrice(requestForm.getExpectedPrice())
                 .expectedAt(requestForm.getExpectedAt())
+                .address(requestForm.getMember().getAddress().getRoadAddress())
+                .addressDetail(requestForm.getMember().getAddress().getAddressDetail())
                 .mainImageUrl(requestForm.getRecipe().getMainImageUrl())
                 .recipeTitle(requestForm.getRecipe().getSummary().getTitle())
                 .recipeContent(requestForm.getRecipe().getSummary().getContent())

--- a/src/main/java/com/zerobase/foodlier/module/requestform/service/RequestFormServiceImpl.java
+++ b/src/main/java/com/zerobase/foodlier/module/requestform/service/RequestFormServiceImpl.java
@@ -98,7 +98,7 @@ public class RequestFormServiceImpl implements RequestFormService {
         RequestForm requestForm = requestFormRepository.findById(requestFormId)
                 .orElseThrow(() -> new RequestFormException(REQUEST_FORM_NOT_FOUND));
         checkPermission(id, requestForm.getMember().getId());
-        return RequestFormDetailDto.builder()
+        RequestFormDetailDto.RequestFormDetailDtoBuilder builder = RequestFormDetailDto.builder()
                 .requestFormId(requestForm.getId())
                 .requesterNickname(requestForm.getMember().getNickname())
                 .title(requestForm.getTitle())
@@ -109,12 +109,16 @@ public class RequestFormServiceImpl implements RequestFormService {
                 .expectedPrice(requestForm.getExpectedPrice())
                 .expectedAt(requestForm.getExpectedAt())
                 .address(requestForm.getMember().getAddress().getRoadAddress())
-                .addressDetail(requestForm.getMember().getAddress().getAddressDetail())
-                .mainImageUrl(requestForm.getRecipe().getMainImageUrl())
-                .recipeTitle(requestForm.getRecipe().getSummary().getTitle())
-                .recipeContent(requestForm.getRecipe().getSummary().getContent())
-                .heartCount(requestForm.getRecipe().getHeartCount())
-                .build();
+                .addressDetail(requestForm.getMember().getAddress().getAddressDetail());
+
+        if (!Objects.isNull(requestForm.getRecipe())) {
+            builder.mainImageUrl(requestForm.getRecipe().getMainImageUrl())
+                    .recipeTitle(requestForm.getRecipe().getSummary().getTitle())
+                    .recipeContent(requestForm.getRecipe().getSummary().getContent())
+                    .heartCount(requestForm.getRecipe().getHeartCount());
+        }
+
+        return builder.build();
     }
 
     /**

--- a/src/test/java/com/zerobase/foodlier/module/requestForm/service/RequestFormServiceImplTest.java
+++ b/src/test/java/com/zerobase/foodlier/module/requestForm/service/RequestFormServiceImplTest.java
@@ -1,9 +1,11 @@
 package com.zerobase.foodlier.module.requestForm.service;
 
 import com.zerobase.foodlier.module.member.member.domain.model.Member;
+import com.zerobase.foodlier.module.member.member.domain.vo.Address;
 import com.zerobase.foodlier.module.member.member.exception.MemberException;
 import com.zerobase.foodlier.module.member.member.repository.MemberRepository;
 import com.zerobase.foodlier.module.recipe.domain.model.Recipe;
+import com.zerobase.foodlier.module.recipe.domain.vo.Summary;
 import com.zerobase.foodlier.module.recipe.exception.RecipeException;
 import com.zerobase.foodlier.module.recipe.repository.RecipeRepository;
 import com.zerobase.foodlier.module.request.domain.vo.Ingredient;
@@ -25,6 +27,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 
+import javax.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -60,12 +63,23 @@ class RequestFormServiceImplTest {
         static Long constRequestFormId = 10L;
         static Member constMember = Member.builder()
                 .id(constMemberId)
+                .address(Address.builder()
+                        .roadAddress("road")
+                        .addressDetail("detail")
+                        .build())
+                .nickname("nickname")
                 .build();
         static Recipe constRecipe = Recipe.builder()
                 .id(constRecipeId)
                 .isPublic(true)
                 .isDeleted(false)
                 .isQuotation(false)
+                .mainImageUrl("url")
+                .summary(Summary.builder()
+                        .title("title")
+                        .content("content")
+                        .build())
+                .heartCount(0)
                 .build();
         static Recipe constRecipeNotPublic = Recipe.builder()
                 .id(constRecipeId)
@@ -138,6 +152,7 @@ class RequestFormServiceImplTest {
 
     @Test
     @DisplayName("요청서 작성 성공 - 레시피 태그하지 않음")
+    @Transactional
     void success_create_request_form_no_tag() {
         //given
         Long id = constRequesterId;
@@ -162,12 +177,13 @@ class RequestFormServiceImplTest {
                 () -> assertEquals(requestFormDto.getIngredientList().get(0),
                         requestForm.getIngredientList().get(0).getIngredientName()),
                 () -> assertEquals(member, requestForm.getMember()),
-                () -> assertEquals(null, requestForm.getRecipe())
+                () -> assertNull(requestForm.getRecipe())
         );
     }
 
     @Test
     @DisplayName("요청서 작성 성공 - 레시피 태그")
+    @Transactional
     void success_create_request_form_tag() {
         //given
         Long id = constRequesterId;
@@ -366,7 +382,14 @@ class RequestFormServiceImplTest {
                         requestFormDetailDto.getIngredientList().get(0)),
                 () -> assertEquals(requestForm.getExpectedPrice(), requestFormDetailDto.getExpectedPrice()),
                 () -> assertEquals(requestForm.getExpectedAt(), requestFormDetailDto.getExpectedAt()),
-                () -> assertEquals(requestForm.getRecipe(), requestFormDetailDto.getRecipe())
+                () -> assertEquals(requestForm.getMember().getAddress().getRoadAddress(), requestFormDetailDto.getAddress()),
+                () -> assertEquals(requestForm.getMember().getAddress().getAddressDetail(), requestFormDetailDto.getAddressDetail()),
+                () -> assertEquals(requestForm.getMember().getAddress().getAddressDetail(), requestFormDetailDto.getAddressDetail()),
+                () -> assertEquals(requestForm.getRecipe().getMainImageUrl(), requestFormDetailDto.getMainImageUrl()),
+                () -> assertEquals(requestForm.getRecipe().getSummary().getTitle(), requestFormDetailDto.getRecipeTitle()),
+                () -> assertEquals(requestForm.getRecipe().getSummary().getContent(), requestFormDetailDto.getRecipeContent()),
+                () -> assertEquals(requestForm.getRecipe().getHeartCount(), requestFormDetailDto.getHeartCount()),
+                () -> assertEquals(requestForm.getMember().getNickname(), requestFormDetailDto.getRequesterNickname())
         );
     }
 
@@ -409,6 +432,7 @@ class RequestFormServiceImplTest {
 
     @Test
     @DisplayName("요청서 수정 성공")
+    @Transactional
     void success_update_request_form() {
         //given
         Long id = constRequesterId;
@@ -592,6 +616,7 @@ class RequestFormServiceImplTest {
 
     @Test
     @DisplayName("요청서 삭제 성공")
+    @Transactional
     void success_delete_request_form() {
         //given
         Long id = constRequesterId;

--- a/src/test/java/com/zerobase/foodlier/module/requestForm/service/RequestFormServiceImplTest.java
+++ b/src/test/java/com/zerobase/foodlier/module/requestForm/service/RequestFormServiceImplTest.java
@@ -27,7 +27,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 
-import javax.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -152,7 +151,6 @@ class RequestFormServiceImplTest {
 
     @Test
     @DisplayName("요청서 작성 성공 - 레시피 태그하지 않음")
-    @Transactional
     void success_create_request_form_no_tag() {
         //given
         Long id = constRequesterId;
@@ -183,7 +181,6 @@ class RequestFormServiceImplTest {
 
     @Test
     @DisplayName("요청서 작성 성공 - 레시피 태그")
-    @Transactional
     void success_create_request_form_tag() {
         //given
         Long id = constRequesterId;
@@ -432,7 +429,6 @@ class RequestFormServiceImplTest {
 
     @Test
     @DisplayName("요청서 수정 성공")
-    @Transactional
     void success_update_request_form() {
         //given
         Long id = constRequesterId;
@@ -616,7 +612,6 @@ class RequestFormServiceImplTest {
 
     @Test
     @DisplayName("요청서 삭제 성공")
-    @Transactional
     void success_delete_request_form() {
         //given
         Long id = constRequesterId;


### PR DESCRIPTION
## Summary

## Describe your changes
요청서 상세보기에서 반환값으로 요청자 이름을 추가하였습니다.
또한 이전 hotfix #106 에서 recipe를 가져오던 로직에서 각각의 값을 가져오는 것으로 수정하였고, 이 부분에서 레시피가 태그되지 않았을 경우 builder에서 추가로 넣는 것으로 수정하였습니다.
해당 로직 수정에 따라 테스트코드 일부 수정하였습니다.

## Issue number and link
#65 