### PR TITLE
BE - 주변 요청 조회하기

### DIFF
--- a/src/main/java/com/zerobase/foodlier/global/refrigerator/controller/RefrigeratorController.java
+++ b/src/main/java/com/zerobase/foodlier/global/refrigerator/controller/RefrigeratorController.java
@@ -6,6 +6,9 @@ import com.zerobase.foodlier.module.member.chef.dto.AroundChefDto;
 import com.zerobase.foodlier.module.member.chef.dto.RequestedChefDto;
 import com.zerobase.foodlier.module.member.chef.service.ChefMemberService;
 import com.zerobase.foodlier.module.member.chef.type.ChefSearchType;
+import com.zerobase.foodlier.module.member.member.dto.RequestedMemberDto;
+import com.zerobase.foodlier.module.member.member.service.MemberService;
+import com.zerobase.foodlier.module.member.member.type.RequestedOrderingType;
 import com.zerobase.foodlier.module.request.service.RequestService;
 import com.zerobase.foodlier.module.requestform.dto.RequestFormDetailDto;
 import com.zerobase.foodlier.module.requestform.dto.RequestFormDto;
@@ -13,6 +16,7 @@ import com.zerobase.foodlier.module.requestform.dto.RequestFormResponseDto;
 import com.zerobase.foodlier.module.requestform.service.RequestFormService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -28,6 +32,7 @@ public class RefrigeratorController {
     private final RefrigeratorFacade refrigeratorFacade;
     private final ChefMemberService chefMemberService;
     private final RequestFormService requestFormService;
+    private final MemberService memberService;
 
     @PatchMapping("/send")
     public ResponseEntity<String> sendRequest(
@@ -149,6 +154,19 @@ public class RefrigeratorController {
         return ResponseEntity.ok(
                 chefMemberService.getAroundChefList(memberAuthDto.getId(),
                         pageIdx, pageSize, type)
+        );
+    }
+
+    @GetMapping("/requester/{pageIdx}/{pageSize}")
+    public ResponseEntity<List<RequestedMemberDto>> getRequestedMemberList(
+            @AuthenticationPrincipal MemberAuthDto memberAuthDto,
+            @PathVariable int pageIdx,
+            @PathVariable int pageSize,
+            @RequestParam("type") RequestedOrderingType type
+    ){
+        return ResponseEntity.ok(
+                memberService.getRequestedMemberList(memberAuthDto.getId(),
+                        type, PageRequest.of(pageIdx, pageSize))
         );
     }
 }

--- a/src/main/java/com/zerobase/foodlier/module/member/member/dto/RequestedMemberDto.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/member/dto/RequestedMemberDto.java
@@ -1,0 +1,16 @@
+package com.zerobase.foodlier.module.member.member.dto;
+
+public interface RequestedMemberDto {
+
+    Long getMemberId();
+    String getProfileUrl();
+    String getNickname();
+    double getDistance();
+    double getLat();
+    double getLnt();
+    Long getRequestId();
+    Long getExpectedPrice();
+    String getTitle();
+    String getMainImageUrl();
+
+}

--- a/src/main/java/com/zerobase/foodlier/module/member/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/member/exception/MemberErrorCode.java
@@ -10,7 +10,8 @@ public enum MemberErrorCode {
     EMAIL_IS_ALREADY_EXIST("이미 사용 중인 이메일 입니다."),
     NICKNAME_IS_ALREADY_EXIST("이미 사용 중인 닉네임 입니다."),
     PHONE_NUMBER_IS_ALREADY_EXIST("이미 사용 중인 핸드폰 번호 입니다."),
-    MEMBER_IS_NOT_CHEF("요리사가 아닌 회원입니다.");
+    MEMBER_IS_NOT_CHEF("요리사가 아닌 회원입니다."),
+    ORDER_TYPE_IS_NULL("정렬타입이 지정되지 않았습니다.");
 
     private final String description;
 }

--- a/src/main/java/com/zerobase/foodlier/module/member/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/member/exception/MemberErrorCode.java
@@ -9,7 +9,8 @@ public enum MemberErrorCode {
     MEMBER_NOT_FOUND("회원을 찾을 수 없습니다"),
     EMAIL_IS_ALREADY_EXIST("이미 사용 중인 이메일 입니다."),
     NICKNAME_IS_ALREADY_EXIST("이미 사용 중인 닉네임 입니다."),
-    PHONE_NUMBER_IS_ALREADY_EXIST("이미 사용 중인 핸드폰 번호 입니다.");
+    PHONE_NUMBER_IS_ALREADY_EXIST("이미 사용 중인 핸드폰 번호 입니다."),
+    MEMBER_IS_NOT_CHEF("요리사가 아닌 회원입니다.");
 
     private final String description;
 }

--- a/src/main/java/com/zerobase/foodlier/module/member/member/repository/MemberRepository.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/member/repository/MemberRepository.java
@@ -1,7 +1,12 @@
 package com.zerobase.foodlier.module.member.member.repository;
 
 import com.zerobase.foodlier.module.member.member.domain.model.Member;
+import com.zerobase.foodlier.module.member.member.dto.RequestedMemberDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -11,5 +16,47 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
     boolean existsByNickname(String nickname);
     boolean existsByPhoneNumber(String phoneNumber);
+
+    String baseRequestedMemberQuery =
+            "SELECT m.id as memberId, m.profile_url as profileUrl, m.nickname as nickname,\n" +
+            "ROUND(st_distance_sphere(point(m.lnt, m.lat), point(:lnt, :lat))/1000, 2) as distance,\n" +
+            "m.lat as lat, m.lnt as lnt, r.id as requestId, r.title as title, r.expected_price as expectedPrice, \n" +
+            "rp.main_image_url as mainImageUrl\n" +
+            "FROM chef_member cm\n" +
+            "JOIN cook_request r ON r.chef_member_id = cm.id AND r.is_paid = false AND r.dm_room_id IS NULL\n" +
+            "JOIN member m ON m.id = r.member_id\n" +
+            "LEFT JOIN recipe rp ON rp.id = r.recipe_id\n" +
+            "WHERE cm.id = :chefMemberId\n";
+    String requestedMemberCountQuery =
+            "SELECT COUNT(*)\n" +
+            "FROM chef_member cm\n" +
+            "JOIN cook_request r ON r.chef_member_id = cm.id AND r.is_paid = false AND r.dm_room_id IS NULL\n" +
+            "JOIN member m ON m.id = r.member_id\n" +
+            "LEFT JOIN recipe rp ON rp.id = r.recipe_id\n" +
+            "WHERE cm.id = :chefMemberId\n";
+
+    @Query(
+            value = baseRequestedMemberQuery + "ORDER BY distance ASC",
+            countQuery = requestedMemberCountQuery,
+            nativeQuery = true
+    )
+    Page<RequestedMemberDto> getRequestedMemberListOrderByDistance(
+            @Param("chefMemberId")Long chefMemberId,
+            @Param("lat")double lat,
+            @Param("lnt")double lnt,
+            Pageable pageable
+    );
+    @Query(
+            value = baseRequestedMemberQuery + "ORDER BY expectedPrice ASC",
+            countQuery = requestedMemberCountQuery,
+            nativeQuery = true
+    )
+    Page<RequestedMemberDto> getRequestedMemberListOrderByPrice(
+            @Param("chefMemberId")Long chefMemberId,
+            @Param("lat")double lat,
+            @Param("lnt")double lnt,
+            Pageable pageable
+    );
+
 
 }

--- a/src/main/java/com/zerobase/foodlier/module/member/member/service/MemberService.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/member/service/MemberService.java
@@ -3,10 +3,15 @@ package com.zerobase.foodlier.module.member.member.service;
 import com.zerobase.foodlier.module.member.member.dto.MemberRegisterDto;
 
 import com.zerobase.foodlier.common.security.provider.dto.TokenDto;
+import com.zerobase.foodlier.module.member.member.dto.RequestedMemberDto;
 import com.zerobase.foodlier.module.member.member.dto.SignInForm;
 import com.zerobase.foodlier.module.member.member.profile.dto.MemberPrivateProfileResponse;
 import com.zerobase.foodlier.module.member.member.domain.model.Member;
 import com.zerobase.foodlier.module.member.member.profile.dto.MemberUpdateDto;
+import com.zerobase.foodlier.module.member.member.type.RequestedOrderingType;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 public interface MemberService {
     void register(MemberRegisterDto memberRegisterDto);
@@ -17,6 +22,9 @@ public interface MemberService {
     MemberPrivateProfileResponse getPrivateProfile(String email);
 
     void updatePrivateProfile(MemberUpdateDto memberUpdateDto,Member member);
+    List<RequestedMemberDto> getRequestedMemberList(Long memberId,
+                                                    RequestedOrderingType type,
+                                                    Pageable pageable);
 
     Member findByEmail(String email);
 }

--- a/src/main/java/com/zerobase/foodlier/module/member/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/member/service/MemberServiceImpl.java
@@ -164,12 +164,15 @@ public class MemberServiceImpl implements MemberService {
                         member.getAddress().getLnt(),
                         pageable
                 ).getContent();
+            case DISTANCE:
+                return memberRepository.getRequestedMemberListOrderByDistance(
+                    member.getChefMember().getId(), member.getAddress().getLat(),
+                    member.getAddress().getLnt(),
+                    pageable
+            ).getContent();
+
         }
-        return memberRepository.getRequestedMemberListOrderByDistance(
-                member.getChefMember().getId(), member.getAddress().getLat(),
-                member.getAddress().getLnt(),
-                pageable
-        ).getContent();
+        throw new MemberException(ORDER_TYPE_IS_NULL);
     }
 
     @Override

--- a/src/main/java/com/zerobase/foodlier/module/member/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/member/service/MemberServiceImpl.java
@@ -3,6 +3,7 @@ package com.zerobase.foodlier.module.member.member.service;
 import com.zerobase.foodlier.common.security.provider.JwtTokenProvider;
 import com.zerobase.foodlier.common.security.provider.dto.MemberAuthDto;
 import com.zerobase.foodlier.common.security.provider.dto.TokenDto;
+import com.zerobase.foodlier.module.member.member.dto.RequestedMemberDto;
 import com.zerobase.foodlier.module.member.member.dto.SignInForm;
 import com.zerobase.foodlier.module.member.member.profile.dto.MemberPrivateProfileResponse;
 import com.zerobase.foodlier.module.member.member.domain.model.Member;
@@ -11,8 +12,10 @@ import com.zerobase.foodlier.module.member.member.dto.MemberRegisterDto;
 import com.zerobase.foodlier.module.member.member.exception.MemberException;
 import com.zerobase.foodlier.module.member.member.profile.dto.MemberUpdateDto;
 import com.zerobase.foodlier.module.member.member.repository.MemberRepository;
+import com.zerobase.foodlier.module.member.member.type.RequestedOrderingType;
 import com.zerobase.foodlier.module.member.member.type.RoleType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
@@ -137,6 +140,37 @@ public class MemberServiceImpl implements MemberService {
         memberRepository.save(member);
     }
 
+    /**
+     *  작성자 : 전현서
+     *  작성일 : 2023-10-04
+     *  냉장고를 부탁해 페이지에서, 요리사 입장에서 요청한 주변 요리사를 페이징하여 조회함.
+     *  정렬 조건 확장 가능성을 위해서, switch문으로 구현함.
+     *  값이 없으면 기본적으로 가까운 거리순으로 반환함.
+     */
+    @Override
+    public List<RequestedMemberDto> getRequestedMemberList(Long memberId,
+                                                           RequestedOrderingType type,
+                                                           Pageable pageable){
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+
+        validateGetRequestedMemberList(member);
+
+        switch (type){
+            case PRICE:
+                return memberRepository.getRequestedMemberListOrderByPrice(
+                        member.getChefMember().getId(), member.getAddress().getLat(),
+                        member.getAddress().getLnt(),
+                        pageable
+                ).getContent();
+        }
+        return memberRepository.getRequestedMemberListOrderByDistance(
+                member.getChefMember().getId(), member.getAddress().getLat(),
+                member.getAddress().getLnt(),
+                pageable
+        ).getContent();
+    }
+
     @Override
     public Member findByEmail(String email) {
         return memberRepository.findByEmail(email)
@@ -165,6 +199,12 @@ public class MemberServiceImpl implements MemberService {
         if (StringUtils.hasText(memberUpdateDto.getPhoneNumber())
                 && memberRepository.existsByPhoneNumber(memberUpdateDto.getPhoneNumber())) {
             throw new MemberException(PHONE_NUMBER_IS_ALREADY_EXIST);
+        }
+    }
+
+    private void validateGetRequestedMemberList(Member member){
+        if(member.getChefMember() == null){
+            throw new MemberException(MEMBER_IS_NOT_CHEF);
         }
     }
 }

--- a/src/main/java/com/zerobase/foodlier/module/member/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/member/service/MemberServiceImpl.java
@@ -31,6 +31,7 @@ import static com.zerobase.foodlier.module.member.member.exception.MemberErrorCo
 @RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
 
+    private static final Object NOT_CHEF_MEMBER = null;
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider tokenProvider;
@@ -203,7 +204,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     private void validateGetRequestedMemberList(Member member){
-        if(member.getChefMember() == null){
+        if(member.getChefMember() == NOT_CHEF_MEMBER){
             throw new MemberException(MEMBER_IS_NOT_CHEF);
         }
     }

--- a/src/main/java/com/zerobase/foodlier/module/member/member/type/RequestedOrderingType.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/member/type/RequestedOrderingType.java
@@ -1,0 +1,5 @@
+package com.zerobase.foodlier.module.member.member.type;
+
+public enum RequestedOrderingType {
+    DISTANCE, PRICE
+}


### PR DESCRIPTION
## Summary
- 주변 요청 조회하기

## Describe your changes
```MYSQL
SELECT m.id as memberId, m.profile_url as profileUrl, m.nickname as nickname,
ROUND(st_distance_sphere(point(m.lnt, m.lat), point(127.1, 37.1))/1000, 2) as distance,
m.lat as lat, m.lnt as lnt, r.id as requestId, r.title as title, r.expected_price as expectedPrice, 
rp.main_image_url as mainImageUrl
FROM chef_member cm
JOIN cook_request r ON r.chef_member_id = cm.id AND r.is_paid = false AND r.dm_room_id IS NULL
JOIN member m ON m.id = r.member_id
LEFT JOIN recipe rp ON rp.id = r.recipe_id
WHERE cm.id = 2
ORDER BY distance ASC
LIMIT 0, 10;
```
- 요리사 입장에서, 주변 요청을 조회하는 NativeQuery 작성
- cook_request 테이블과 JOIN하여, 결제가 수행되지 않았고, Dm방이 존재하지 않는 요청을 대상으로 조회
- Recipe 태깅이 되지 않을 수도 있으므로, LEFT JOIN으로 레코드 누락을 방지
- 정렬 기준은, 가까운 거리순, 적은 금액순을 ENUM타입으로 받아서 정렬하도록 구성

## Issue number and link
#132 
