### PR TITLE
BE - 댓글 및 대댓글 기능 구현

### DIFF
--- a/src/main/java/com/zerobase/foodlier/global/comment/controller/CommentController.java
+++ b/src/main/java/com/zerobase/foodlier/global/comment/controller/CommentController.java
@@ -1,0 +1,103 @@
+package com.zerobase.foodlier.global.comment.controller;
+
+import com.zerobase.foodlier.common.security.provider.dto.MemberAuthDto;
+import com.zerobase.foodlier.global.comment.facade.comment.CommentFacade;
+import com.zerobase.foodlier.global.comment.facade.reply.ReplyFacade;
+import com.zerobase.foodlier.module.comment.comment.dto.CommentPagingDto;
+import com.zerobase.foodlier.module.comment.comment.service.CommentServiceImpl;
+import com.zerobase.foodlier.module.comment.reply.dto.ReplyPagingDto;
+import com.zerobase.foodlier.module.comment.reply.servcie.ReplyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/comment")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentFacade commentFacade;
+    private final CommentServiceImpl commentService;
+    private final ReplyFacade replyFacade;
+    private final ReplyService replyService;
+
+    // ======================== 댓글 api ======================================
+    @PostMapping("/{recipeId}")
+    public ResponseEntity<String> createComment(@AuthenticationPrincipal MemberAuthDto memberAuthDto,
+                                                @PathVariable Long recipeId,
+                                                @RequestBody String message)
+    {
+        commentFacade.createComment(recipeId, memberAuthDto.getEmail(), message);
+        return ResponseEntity.ok("댓글 작성이 완료되었습니다.");
+    }
+
+    @PutMapping("/{commentId}")
+    public ResponseEntity<String> updateComment(@AuthenticationPrincipal MemberAuthDto memberAuthDto,
+                                                @PathVariable Long commentId,
+                                                @RequestBody String modifiedMessage)
+    {
+        commentService.updateComment(memberAuthDto.getId(), commentId, modifiedMessage);
+        return ResponseEntity.ok("댓글 수정이 완료되었습니다.");
+    }
+
+    @DeleteMapping("/{recipeId}/{commentId}")
+    public ResponseEntity<String> deleteComment(@AuthenticationPrincipal MemberAuthDto memberAuthDto,
+                                                @PathVariable Long recipeId,
+                                                @PathVariable Long commentId) {
+        commentFacade.deleteComment(recipeId, commentId, memberAuthDto.getId());
+        return ResponseEntity.ok("댓글이 삭제되었습니다.");
+    }
+
+    @GetMapping("/{recipeId}/{pageIdx}/{pageSize}")
+    public ResponseEntity<CommentPagingDto> getCommentList(@PathVariable int pageIdx,
+                                                           @PathVariable int pageSize,
+                                                           @PathVariable Long recipeId)
+    {
+        return ResponseEntity.ok(commentService.getCommentList(recipeId,
+                PageRequest.of(pageIdx, pageSize)));
+    }
+
+
+    // ======================== 답글 api ======================================
+    @PostMapping("/reply/{recipeId}/{commentId}")
+    public ResponseEntity<String> createReply(@AuthenticationPrincipal MemberAuthDto memberAuthDto,
+                                              @PathVariable Long recipeId,
+                                              @PathVariable Long commentId,
+                                              @RequestBody String message)
+    {
+        replyFacade.createReply(commentId, recipeId, memberAuthDto.getEmail(), message);
+        return ResponseEntity.ok("답글 작성이 완료되었습니다.");
+    }
+
+    @PutMapping("/reply/{replyId}")
+    public ResponseEntity<String> updateReply(@AuthenticationPrincipal MemberAuthDto memberAuthDto,
+                                              @PathVariable Long replyId,
+                                              @RequestBody String message)
+    {
+        replyService.updateReply(memberAuthDto.getId(), replyId, message);
+        return ResponseEntity.ok("답글 수정이 완료되었습니다.");
+    }
+
+    @DeleteMapping("/reply/{recipeId}/{replyId}")
+    public ResponseEntity<String> deleteRely(@AuthenticationPrincipal MemberAuthDto memberAuthDto,
+                                             @PathVariable Long recipeId,
+                                             @PathVariable Long replyId)
+    {
+        replyFacade.deleteReply(replyId, recipeId, memberAuthDto.getId());
+        return ResponseEntity.ok("답글이 삭제되었습니다.");
+    }
+
+    @GetMapping("/reply/{commentId}/{pageIdx}/{pageSize}")
+    public ResponseEntity<ReplyPagingDto> getReplyList(@AuthenticationPrincipal MemberAuthDto memberAuthDto,
+                                                       @PathVariable Long commentId,
+                                                       @PathVariable int pageIdx,
+                                                       @PathVariable int pageSize)
+    {
+        return ResponseEntity.ok(replyService.getReplyList(commentId,
+                PageRequest.of(pageIdx, pageSize)));
+    }
+
+
+}

--- a/src/main/java/com/zerobase/foodlier/global/comment/facade/comment/CommentFacade.java
+++ b/src/main/java/com/zerobase/foodlier/global/comment/facade/comment/CommentFacade.java
@@ -1,0 +1,45 @@
+package com.zerobase.foodlier.global.comment.facade.comment;
+
+import com.zerobase.foodlier.common.aop.RedissonLock;
+import com.zerobase.foodlier.module.comment.comment.domain.model.Comment;
+import com.zerobase.foodlier.module.comment.comment.service.CommentService;
+import com.zerobase.foodlier.module.comment.comment.service.CommentServiceImpl;
+import com.zerobase.foodlier.module.member.member.domain.model.Member;
+import com.zerobase.foodlier.module.member.member.service.MemberService;
+import com.zerobase.foodlier.module.recipe.domain.model.Recipe;
+import com.zerobase.foodlier.module.recipe.service.recipe.RecipeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentFacade {
+
+    private final CommentService commentService;
+    private final RecipeService recipeService;
+    private final MemberService memberService;
+    @Transactional
+    @RedissonLock(group = "comment", key = "#recipeId")
+    public void createComment(Long recipeId, String userEmail, String message) {
+
+        Member member = memberService.findByEmail(userEmail);
+
+        Recipe recipe = recipeService.plusCommentCount(recipeId);
+
+        commentService.createComment(Comment.builder()
+                .message(message)
+                .isDeleted(false)
+                .recipe(recipe)
+                .member(member)
+                .build());
+    }
+
+    @Transactional
+    @RedissonLock(group = "comment", key = "#recipeId")
+    public void deleteComment(Long recipeId, Long commentId, Long memberId) {
+        recipeService.minusCommentCount(recipeId);
+        commentService.deleteComment(memberId, commentId);
+    }
+
+}

--- a/src/main/java/com/zerobase/foodlier/global/comment/facade/reply/ReplyFacade.java
+++ b/src/main/java/com/zerobase/foodlier/global/comment/facade/reply/ReplyFacade.java
@@ -1,0 +1,48 @@
+package com.zerobase.foodlier.global.comment.facade.reply;
+
+import com.zerobase.foodlier.common.aop.RedissonLock;
+import com.zerobase.foodlier.module.comment.comment.domain.model.Comment;
+import com.zerobase.foodlier.module.comment.comment.service.CommentService;
+import com.zerobase.foodlier.module.comment.reply.domain.model.Reply;
+import com.zerobase.foodlier.module.comment.reply.servcie.ReplyService;
+import com.zerobase.foodlier.module.member.member.domain.model.Member;
+import com.zerobase.foodlier.module.member.member.service.MemberService;
+import com.zerobase.foodlier.module.recipe.domain.model.Recipe;
+import com.zerobase.foodlier.module.recipe.service.recipe.RecipeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReplyFacade {
+
+    private final ReplyService replyService;
+    private final CommentService commentService;
+    private final MemberService memberService;
+    private final RecipeService recipeService;
+
+    @Transactional
+    @RedissonLock(group = "reply", key = "#recipeId")
+    public void createReply(Long commentId, Long recipeId, String userEmail, String message) {
+
+        Member member = memberService.findByEmail(userEmail);
+
+        Recipe recipe = recipeService.plusCommentCount(recipeId);
+        Comment comment = commentService.findComment(commentId);
+        replyService.createReply(Reply.builder()
+                .message(message)
+                .comment(comment)
+                .member(member)
+                .build());
+    }
+
+    @Transactional
+    @RedissonLock(group = "reply", key = "#recipeId")
+    public void deleteReply(Long replyId, Long recipeId, Long memberId) {
+        recipeService.minusCommentCount(recipeId);
+        replyService.deleteReply(memberId,replyId);
+    }
+
+
+}

--- a/src/main/java/com/zerobase/foodlier/global/comment/facade/reply/ReplyFacade.java
+++ b/src/main/java/com/zerobase/foodlier/global/comment/facade/reply/ReplyFacade.java
@@ -23,7 +23,7 @@ public class ReplyFacade {
     private final RecipeService recipeService;
 
     @Transactional
-    @RedissonLock(group = "reply", key = "#recipeId")
+    @RedissonLock(group = "comment", key = "#recipeId")
     public void createReply(Long commentId, Long recipeId, String userEmail, String message) {
 
         Member member = memberService.findByEmail(userEmail);
@@ -38,7 +38,7 @@ public class ReplyFacade {
     }
 
     @Transactional
-    @RedissonLock(group = "reply", key = "#recipeId")
+    @RedissonLock(group = "comment", key = "#recipeId")
     public void deleteReply(Long replyId, Long recipeId, Long memberId) {
         recipeService.minusCommentCount(recipeId);
         replyService.deleteReply(memberId,replyId);

--- a/src/main/java/com/zerobase/foodlier/module/comment/comment/domain/model/Comment.java
+++ b/src/main/java/com/zerobase/foodlier/module/comment/comment/domain/model/Comment.java
@@ -1,7 +1,9 @@
 package com.zerobase.foodlier.module.comment.comment.domain.model;
 
+import com.zerobase.foodlier.common.aop.notification.dto.Notify;
 import com.zerobase.foodlier.common.jpa.audit.Audit;
 import com.zerobase.foodlier.module.member.member.domain.model.Member;
+import com.zerobase.foodlier.module.notification.domain.type.NotificationType;
 import com.zerobase.foodlier.module.recipe.domain.model.Recipe;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
@@ -20,16 +22,30 @@ public class Comment extends Audit {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     @ManyToOne
     @JoinColumn(name = "member_id")
     private Member member;
+
     @ManyToOne
     @JoinColumn(name = "recipe_id")
     private Recipe recipe;
+
     @Column(nullable = false)
     private String message;
+
     @Builder.Default
     @Column(nullable = false)
     @ColumnDefault("false")
     private boolean isDeleted = false;
+
+    public void updateMessage(String message){
+        this.message = message;
+    }
+
+    public void delete(){
+        if(!this.isDeleted){
+            this.isDeleted = true;
+        }
+    }
 }

--- a/src/main/java/com/zerobase/foodlier/module/comment/comment/dto/CommentDto.java
+++ b/src/main/java/com/zerobase/foodlier/module/comment/comment/dto/CommentDto.java
@@ -1,0 +1,26 @@
+package com.zerobase.foodlier.module.comment.comment.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class CommentDto {
+    private String message;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public CommentDto() {
+
+    }
+
+    public CommentDto(String message,
+                      LocalDateTime createdAt,
+                      LocalDateTime modifiedAt){
+        this.message = message;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+    }
+}

--- a/src/main/java/com/zerobase/foodlier/module/comment/comment/dto/CommentPagingDto.java
+++ b/src/main/java/com/zerobase/foodlier/module/comment/comment/dto/CommentPagingDto.java
@@ -1,0 +1,21 @@
+package com.zerobase.foodlier.module.comment.comment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CommentPagingDto {
+
+    private Long totalElements;
+    private int totalPages;
+    private boolean hasNextPage;
+    private List<CommentDto> commentDtoList;
+
+}

--- a/src/main/java/com/zerobase/foodlier/module/comment/comment/exception/CommentErrorCode.java
+++ b/src/main/java/com/zerobase/foodlier/module/comment/comment/exception/CommentErrorCode.java
@@ -7,7 +7,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum CommentErrorCode {
 
-    NEW_ENUM("enum 추가");
+    NO_SUCH_COMMENT("댓글을 찾을 수 없습니다."),
+    ALREADY_DELETED("댓글이 이미 삭제되었습니다."),
+    ;
 
     private final String description;
 }

--- a/src/main/java/com/zerobase/foodlier/module/comment/comment/repository/CommentRepository.java
+++ b/src/main/java/com/zerobase/foodlier/module/comment/comment/repository/CommentRepository.java
@@ -17,14 +17,14 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             "from Comment c " +
             "join c.recipe r " +
             "where r.id=:recipeId " +
-            "order by c.createdAt desc")
+            "order by c.createdAt asc ")
     Page<CommentDto> findCommentList(@Param("recipeId") Long recipeId,
                                      Pageable pageable);
 
     @Query("select c " +
             "from Comment c " +
             "join c.member m " +
-            "where m.id = :memberId and c.id=:commentId")
+            "where m.id = :memberId and c.id=:commentId ")
     Optional<Comment> findComment(@Param("memberId") Long memberId,
                                   @Param("commentId") Long commentId);
 

--- a/src/main/java/com/zerobase/foodlier/module/comment/comment/repository/CommentRepository.java
+++ b/src/main/java/com/zerobase/foodlier/module/comment/comment/repository/CommentRepository.java
@@ -1,8 +1,32 @@
 package com.zerobase.foodlier.module.comment.comment.repository;
 
 import com.zerobase.foodlier.module.comment.comment.domain.model.Comment;
+import com.zerobase.foodlier.module.comment.comment.dto.CommentDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @Query("select new com.zerobase.foodlier.module.comment.comment.dto.CommentDto(" +
+            "c.message, c.createdAt, c.modifiedAt) " +
+            "from Comment c " +
+            "join c.recipe r " +
+            "where r.id=:recipeId " +
+            "order by c.createdAt desc")
+    Page<CommentDto> findCommentList(@Param("recipeId") Long recipeId,
+                                     Pageable pageable);
+
+    @Query("select c " +
+            "from Comment c " +
+            "join c.member m " +
+            "where m.id = :memberId and c.id=:commentId")
+    Optional<Comment> findComment(@Param("memberId") Long memberId,
+                                  @Param("commentId") Long commentId);
+
+
 }

--- a/src/main/java/com/zerobase/foodlier/module/comment/comment/service/CommentService.java
+++ b/src/main/java/com/zerobase/foodlier/module/comment/comment/service/CommentService.java
@@ -1,7 +1,15 @@
 package com.zerobase.foodlier.module.comment.comment.service;
 
+import com.zerobase.foodlier.module.comment.comment.domain.model.Comment;
+import com.zerobase.foodlier.module.comment.comment.dto.CommentPagingDto;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 @Service
 public interface CommentService {
+    void createComment(Comment comment);
+    void updateComment(Long memberId, Long commentId, String modifiedMessage);
+    void deleteComment(Long memberId, Long commentId);
+    CommentPagingDto getCommentList(Long recipeId, PageRequest pageRequest);
+    Comment findComment(Long commentId);
 }

--- a/src/main/java/com/zerobase/foodlier/module/comment/comment/service/CommentService.java
+++ b/src/main/java/com/zerobase/foodlier/module/comment/comment/service/CommentService.java
@@ -3,9 +3,7 @@ package com.zerobase.foodlier.module.comment.comment.service;
 import com.zerobase.foodlier.module.comment.comment.domain.model.Comment;
 import com.zerobase.foodlier.module.comment.comment.dto.CommentPagingDto;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.stereotype.Service;
 
-@Service
 public interface CommentService {
     void createComment(Comment comment);
     void updateComment(Long memberId, Long commentId, String modifiedMessage);

--- a/src/main/java/com/zerobase/foodlier/module/comment/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/zerobase/foodlier/module/comment/comment/service/CommentServiceImpl.java
@@ -1,0 +1,70 @@
+package com.zerobase.foodlier.module.comment.comment.service;
+
+import com.zerobase.foodlier.module.comment.comment.domain.model.Comment;
+import com.zerobase.foodlier.module.comment.comment.dto.CommentDto;
+import com.zerobase.foodlier.module.comment.comment.dto.CommentPagingDto;
+import com.zerobase.foodlier.module.comment.comment.exception.CommentException;
+import com.zerobase.foodlier.module.comment.comment.repository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.zerobase.foodlier.module.comment.comment.exception.CommentErrorCode.ALREADY_DELETED;
+import static com.zerobase.foodlier.module.comment.comment.exception.CommentErrorCode.NO_SUCH_COMMENT;
+
+@Service
+@RequiredArgsConstructor
+public class CommentServiceImpl implements CommentService {
+    private static final String DELETED_MESSAGE = "삭제된 댓글입니다.";
+    private final CommentRepository commentRepository;
+
+    @Override
+    public void createComment(Comment comment) {
+        commentRepository.save(comment);
+    }
+
+    @Override
+    @Transactional
+    public void updateComment(Long memberId, Long commentId, String modifiedMessage) {
+        Comment comment = commentRepository.findComment(memberId, commentId)
+                .orElseThrow(() -> new CommentException(NO_SUCH_COMMENT));
+        comment.updateMessage(modifiedMessage);
+        commentRepository.save(comment);
+    }
+
+    @Override
+    public void deleteComment(Long memberId, Long commentId) {
+
+        Comment comment = commentRepository.findComment(memberId, commentId)
+                .orElseThrow(() -> new CommentException(NO_SUCH_COMMENT));
+        if (comment.isDeleted()) {
+            throw new CommentException(ALREADY_DELETED);
+        }
+        comment.updateMessage(DELETED_MESSAGE);
+        comment.delete();
+        commentRepository.save(comment);
+    }
+
+    @Override
+    public Comment findComment(Long commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentException(NO_SUCH_COMMENT));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CommentPagingDto getCommentList(Long recipeId, PageRequest pageRequest) {
+
+        Page<CommentDto> commentDtoList = commentRepository.findCommentList(recipeId, pageRequest);
+
+        return CommentPagingDto.builder()
+                .hasNextPage(commentDtoList.hasNext())
+                .totalElements(commentDtoList.getTotalElements())
+                .totalPages(commentDtoList.getTotalPages())
+                .commentDtoList(commentDtoList.getContent())
+                .build();
+    }
+
+}

--- a/src/main/java/com/zerobase/foodlier/module/comment/reply/domain/model/Reply.java
+++ b/src/main/java/com/zerobase/foodlier/module/comment/reply/domain/model/Reply.java
@@ -27,4 +27,9 @@ public class Reply extends Audit {
     private Comment comment;
     @Column(nullable = false)
     private String message;
+
+    public void update(String modifiedMessage){
+        this.message = modifiedMessage;
+    }
+
 }

--- a/src/main/java/com/zerobase/foodlier/module/comment/reply/dto/ReplyDto.java
+++ b/src/main/java/com/zerobase/foodlier/module/comment/reply/dto/ReplyDto.java
@@ -1,0 +1,28 @@
+package com.zerobase.foodlier.module.comment.reply.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ReplyDto {
+    private String message;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public ReplyDto(){
+
+    }
+
+    public ReplyDto(String message,
+                    LocalDateTime createdAt,
+                    LocalDateTime modifiedAt)
+    {
+        this.message = message;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+    }
+
+}

--- a/src/main/java/com/zerobase/foodlier/module/comment/reply/dto/ReplyPagingDto.java
+++ b/src/main/java/com/zerobase/foodlier/module/comment/reply/dto/ReplyPagingDto.java
@@ -1,0 +1,21 @@
+package com.zerobase.foodlier.module.comment.reply.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReplyPagingDto {
+
+    private Long totalElements;
+    private int totalPages;
+    private boolean hasNextPage;
+    private List<ReplyDto> replyDtoList;
+
+}

--- a/src/main/java/com/zerobase/foodlier/module/comment/reply/exception/ReplyErrorCode.java
+++ b/src/main/java/com/zerobase/foodlier/module/comment/reply/exception/ReplyErrorCode.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ReplyErrorCode {
 
-    NEW_ENUM("enum 추가");
+    NO_SUCH_REPLY("해당 답글을 찾을 수 없습니다.");
 
     private final String description;
 }

--- a/src/main/java/com/zerobase/foodlier/module/comment/reply/reposiotry/ReplyRepository.java
+++ b/src/main/java/com/zerobase/foodlier/module/comment/reply/reposiotry/ReplyRepository.java
@@ -1,8 +1,29 @@
 package com.zerobase.foodlier.module.comment.reply.reposiotry;
 
 import com.zerobase.foodlier.module.comment.reply.domain.model.Reply;
+import com.zerobase.foodlier.module.comment.reply.dto.ReplyDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface ReplyRepository extends JpaRepository<Reply, Long> {
+
+    @Query("select r " +
+            "from Reply r " +
+            "left join r.member m " +
+            "where m.id = :memberId " +
+            "and r.id = :replyId")
+    Optional<Reply> findReply(@Param("replyId") Long replyId,
+                              @Param("memberId") Long memberId);
+
+    @Query("select r " +
+            "from Reply r " +
+            "join r.comment c " +
+            "where c.id = :commentId")
+    Page<ReplyDto> findReplyList(@Param("commentId") Long commentId,
+                                 Pageable pageable);
 }

--- a/src/main/java/com/zerobase/foodlier/module/comment/reply/reposiotry/ReplyRepository.java
+++ b/src/main/java/com/zerobase/foodlier/module/comment/reply/reposiotry/ReplyRepository.java
@@ -20,10 +20,11 @@ public interface ReplyRepository extends JpaRepository<Reply, Long> {
     Optional<Reply> findReply(@Param("replyId") Long replyId,
                               @Param("memberId") Long memberId);
 
-    @Query("select r " +
+    @Query("select new com.zerobase.foodlier.module.comment.reply.dto.ReplyDto(r.message, r.createdAt, r.modifiedAt) " +
             "from Reply r " +
             "join r.comment c " +
-            "where c.id = :commentId")
+            "where c.id = :commentId " +
+            "order by r.createdAt asc ")
     Page<ReplyDto> findReplyList(@Param("commentId") Long commentId,
                                  Pageable pageable);
 }

--- a/src/main/java/com/zerobase/foodlier/module/comment/reply/servcie/ReplyService.java
+++ b/src/main/java/com/zerobase/foodlier/module/comment/reply/servcie/ReplyService.java
@@ -1,7 +1,15 @@
 package com.zerobase.foodlier.module.comment.reply.servcie;
 
-import org.springframework.stereotype.Service;
+import com.zerobase.foodlier.module.comment.reply.domain.model.Reply;
+import com.zerobase.foodlier.module.comment.reply.dto.ReplyPagingDto;
+import org.springframework.data.domain.PageRequest;
 
-@Service
 public interface ReplyService {
+
+    void createReply(Reply reply);
+
+    void updateReply(Long memberId, Long replyId, String modifiedMessage);
+
+    void deleteReply(Long memberId, Long replyId);
+    ReplyPagingDto getReplyList(Long commentId, PageRequest pageRequest);
 }

--- a/src/main/java/com/zerobase/foodlier/module/comment/reply/servcie/ReplyServiceImpl.java
+++ b/src/main/java/com/zerobase/foodlier/module/comment/reply/servcie/ReplyServiceImpl.java
@@ -1,0 +1,60 @@
+package com.zerobase.foodlier.module.comment.reply.servcie;
+
+import com.zerobase.foodlier.module.comment.reply.domain.model.Reply;
+import com.zerobase.foodlier.module.comment.reply.dto.ReplyDto;
+import com.zerobase.foodlier.module.comment.reply.dto.ReplyPagingDto;
+import com.zerobase.foodlier.module.comment.reply.exception.ReplyException;
+import com.zerobase.foodlier.module.comment.reply.reposiotry.ReplyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.zerobase.foodlier.module.comment.reply.exception.ReplyErrorCode.NO_SUCH_REPLY;
+
+@Service
+@RequiredArgsConstructor
+public class ReplyServiceImpl implements ReplyService{
+
+    private final ReplyRepository replyRepository;
+
+    @Override
+    public void createReply(Reply reply) {
+        replyRepository.save(reply);
+    }
+
+    @Override
+    @Transactional
+    public void updateReply(Long memberId,
+                             Long replyId,
+                             String modifiedMessage) {
+        Reply reply = replyRepository.findReply(replyId, memberId)
+                .orElseThrow(() -> new ReplyException(NO_SUCH_REPLY));
+        reply.update(modifiedMessage);
+        replyRepository.save(reply);
+    }
+    @Override
+    public void deleteReply(Long memberId, Long replyId) {
+        Reply reply = replyRepository.findReply(replyId, memberId)
+                .orElseThrow(() -> new ReplyException(NO_SUCH_REPLY));
+
+        replyRepository.deleteById(reply.getId());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ReplyPagingDto getReplyList(Long commentId, PageRequest pageRequest) {
+
+        Page<ReplyDto> replyList = replyRepository.findReplyList(commentId, pageRequest);
+
+        return ReplyPagingDto.builder()
+                .hasNextPage(replyList.hasNext())
+                .totalElements(replyList.getTotalElements())
+                .totalPages(replyList.getTotalPages())
+                .replyDtoList(replyList.getContent())
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/zerobase/foodlier/module/recipe/domain/document/RecipeDocument.java
+++ b/src/main/java/com/zerobase/foodlier/module/recipe/domain/document/RecipeDocument.java
@@ -1,15 +1,15 @@
 package com.zerobase.foodlier.module.recipe.domain.document;
 
-import com.zerobase.foodlier.module.recipe.domain.model.Recipe;
-import com.zerobase.foodlier.module.recipe.domain.vo.RecipeIngredient;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Mapping;
 import org.springframework.data.elasticsearch.annotations.Setting;
 
 import javax.persistence.Id;
 import java.util.List;
-import java.util.stream.Collectors;
 
 
 @Getter
@@ -45,7 +45,10 @@ public class RecipeDocument {
         this.numberOfHeart = numberOfHeart;
     }
 
-    public void updateNumberOfComment(long numberOfComment) {
-        this.numberOfComment = numberOfComment;
+    public void plusNumberOfComment() {
+        this.numberOfComment++;
+    }
+    public void minusNumberOfComment() {
+        this.numberOfComment--;
     }
 }

--- a/src/main/java/com/zerobase/foodlier/module/recipe/domain/model/Recipe.java
+++ b/src/main/java/com/zerobase/foodlier/module/recipe/domain/model/Recipe.java
@@ -24,7 +24,7 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class Recipe extends Audit {
-
+    private final static int ZERO = 0;
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -37,7 +37,7 @@ public class Recipe extends Audit {
     private int expectedTime;
 
     private int heartCount;
-
+    private int commentCount;
     @Embedded
     private RecipeStatistics recipeStatistics;
 
@@ -83,8 +83,17 @@ public class Recipe extends Audit {
     }
 
     public void minusHeart() {
-        if (heartCount > 0) {
+        if (heartCount > ZERO) {
             this.heartCount--;
         }
     }
+
+    public void plusCommentCount(){
+        ++this.commentCount;
+    }
+
+    public void minusCommentCount(){
+        this.commentCount = Math.max(ZERO, --this.commentCount);
+    }
+
 }

--- a/src/main/java/com/zerobase/foodlier/module/recipe/service/recipe/RecipeService.java
+++ b/src/main/java/com/zerobase/foodlier/module/recipe/service/recipe/RecipeService.java
@@ -27,4 +27,6 @@ public interface RecipeService {
     void plusReviewStar(Long recipeId, int star);
     void updateReviewStar(Long recipeId, int originStar, int newStar);
     void minusReviewStar(Long recipeId, int star);
+    Recipe plusCommentCount(Long recipeId);
+    void minusCommentCount(Long recipeId);
 }

--- a/src/main/java/com/zerobase/foodlier/module/recipe/service/recipe/RecipeServiceImpl.java
+++ b/src/main/java/com/zerobase/foodlier/module/recipe/service/recipe/RecipeServiceImpl.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.zerobase.foodlier.module.recipe.exception.recipe.RecipeErrorCode.NO_SUCH_RECIPE;
@@ -210,6 +211,21 @@ public class RecipeServiceImpl implements RecipeService {
 
         recipe.getRecipeStatistics().minusStar(star);
         recipeRepository.save(recipe);
+    }
+
+    @Override
+    public Recipe plusCommentCount(Long recipeId){
+        Recipe recipe = recipeRepository.findById(recipeId)
+                .orElseThrow(() -> new RecipeException(NO_SUCH_RECIPE));
+        recipe.plusCommentCount();
+        return recipeRepository.save(recipe);
+    }
+
+    @Override
+    public void minusCommentCount(Long recipeId) {
+        Recipe recipe = recipeRepository.findById(recipeId)
+                .orElseThrow(() -> new RecipeException(NO_SUCH_RECIPE));;
+        recipe.minusCommentCount();
     }
 
 }

--- a/src/main/java/com/zerobase/foodlier/module/recipe/service/recipe/RecipeServiceImpl.java
+++ b/src/main/java/com/zerobase/foodlier/module/recipe/service/recipe/RecipeServiceImpl.java
@@ -13,7 +13,6 @@ import com.zerobase.foodlier.module.recipe.exception.recipe.RecipeErrorCode;
 import com.zerobase.foodlier.module.recipe.exception.recipe.RecipeException;
 import com.zerobase.foodlier.module.recipe.repository.RecipeRepository;
 import com.zerobase.foodlier.module.recipe.repository.RecipeSearchRepository;
-import com.zerobase.foodlier.module.review.recipe.exception.RecipeReviewException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -25,6 +24,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.zerobase.foodlier.module.recipe.exception.recipe.RecipeErrorCode.NO_SUCH_RECIPE;
+import static com.zerobase.foodlier.module.recipe.exception.recipe.RecipeErrorCode.NO_SUCH_RECIPE_DOCUMENT;
 
 @Service
 @RequiredArgsConstructor
@@ -215,17 +215,35 @@ public class RecipeServiceImpl implements RecipeService {
 
     @Override
     public Recipe plusCommentCount(Long recipeId){
+        // 레시피의 댓글 수 증가
         Recipe recipe = recipeRepository.findById(recipeId)
                 .orElseThrow(() -> new RecipeException(NO_SUCH_RECIPE));
         recipe.plusCommentCount();
+
+        // 레시피 검색 객체의 댓글 수 증가
+        RecipeDocument recipeDocument = recipeSearchRepository.findById(recipeId)
+                .orElseThrow(() -> new RecipeException(NO_SUCH_RECIPE_DOCUMENT));
+        recipeDocument.plusNumberOfComment();
+        recipeSearchRepository.save(recipeDocument);
+
         return recipeRepository.save(recipe);
     }
 
     @Override
     public void minusCommentCount(Long recipeId) {
+
+        // 레시피 댓글 수 감소
         Recipe recipe = recipeRepository.findById(recipeId)
-                .orElseThrow(() -> new RecipeException(NO_SUCH_RECIPE));;
+                .orElseThrow(() -> new RecipeException(NO_SUCH_RECIPE));
         recipe.minusCommentCount();
+
+        // 레시피 검색 객체의 댓글 수 감소
+        RecipeDocument recipeDocument = recipeSearchRepository.findById(recipeId)
+                .orElseThrow(() -> new RecipeException(NO_SUCH_RECIPE_DOCUMENT));
+        recipeDocument.minusNumberOfComment();
+        recipeSearchRepository.save(recipeDocument);
+
+        recipeRepository.save(recipe);
     }
 
 }


### PR DESCRIPTION
## Summary
댓글 및 대댓글 기능 구현
- 댓글 CRUD
- 대댓글 CRUD
- 레시피 객체의 댓글 수 증감 기능

 
## Describe your changes

- 댓글 CRUD
  - 댓글 생성
    - 댓글 생성 시 레시피의 댓글 수 증가
  - 댓글 수정
  - 댓글 삭제
    - 댓글 삭제 시 레시피의 댓글 수 감소
  - 댓글 조회
  - 레시피에 대해 작성된 댓글 목록 조회
    
- 대댓글 CRUD
  - 대댓글 생성
    - 대댓글 생성 시 레시피의 댓글 수 증가
  - 대댓글 수정
  - 대댓글 삭제
    - 대댓글 삭제 시 레시피의 댓글 수 감소
  - 대댓글 조회
  - 레시피에 대해 작성된 대댓글 목록 조회

- 레시피 객체의 댓글 수 증감 기능
  - 댓글 및 대댓글 생성 또는 삭제 시 레시피의 댓글 수도 증감되도록 구현

## Issue number and link
#101 