### PR TITLE
BE - 등급 정의 및 등급 할당

### DIFF
--- a/src/main/java/com/zerobase/foodlier/module/member/chef/domain/model/ChefMember.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/chef/domain/model/ChefMember.java
@@ -31,6 +31,7 @@ public class ChefMember extends Audit {
 
     public void plusExp(int exp){
         this.exp += exp;
+        this.gradeType = GradeType.getGrade(this.exp);
     }
 
     public void plusStar(int star){

--- a/src/main/java/com/zerobase/foodlier/module/member/chef/domain/model/ChefMember.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/chef/domain/model/ChefMember.java
@@ -31,7 +31,7 @@ public class ChefMember extends Audit {
 
     public void plusExp(int exp){
         this.exp += exp;
-        this.gradeType = GradeType.getGrade(this.exp);
+        setGrade();
     }
 
     public void plusStar(int star){
@@ -46,6 +46,10 @@ public class ChefMember extends Audit {
             return;
         }
         this.starAvg = (double) this.starSum / this.reviewCount;
+    }
+
+    private void setGrade(){
+        this.gradeType = GradeType.getGrade(this.exp);
     }
 
 }

--- a/src/main/java/com/zerobase/foodlier/module/member/chef/type/GradeType.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/chef/type/GradeType.java
@@ -1,5 +1,24 @@
 package com.zerobase.foodlier.module.member.chef.type;
 
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+
+@RequiredArgsConstructor
 public enum GradeType {
-    BRONZE, SILVER, GOLD, PLATINUM
+    BRONZE(0, 200),
+    SILVER(201, 500),
+    GOLD(501, 800),
+    PLATINUM(801, Long.MAX_VALUE);
+
+    private final long minExp;
+    private final long maxExp;
+
+    public static GradeType getGrade(long exp) {
+        return Arrays.stream(values())
+                .filter(grade -> exp >= grade.minExp && exp <= grade.maxExp)
+                .findFirst()
+                .orElseGet(() -> BRONZE);
+    }
 }


### PR DESCRIPTION
## Summary
- 경험치를 기준으로 등급을 할당하는 기능 구현

## Describe your changes
- ENUM 타입에 등급에 대한 최소 경험치, 최대 경험치를 지정하였음.
- 이에 대해서 getGrade()메서드를 호출시, 이에 해당되는 등급의 ENUM을 반환함.
- ChefMember에서는 이를 가져와, 경험치에 대한 등급을 지정함.

## Issue number and link
#175
