### PR TITLE
BE - 도메인 회원가입 이미지 처리 방식 수정

### DIFF
--- a/src/main/java/com/zerobase/foodlier/global/member/regiser/facade/MemberRegisterFacade.java
+++ b/src/main/java/com/zerobase/foodlier/global/member/regiser/facade/MemberRegisterFacade.java
@@ -2,7 +2,6 @@ package com.zerobase.foodlier.global.member.regiser.facade;
 
 import com.zerobase.foodlier.common.redis.service.EmailVerificationService;
 import com.zerobase.foodlier.common.s3.service.S3Service;
-import com.zerobase.foodlier.module.member.member.constants.ProfileUrlConstants;
 import com.zerobase.foodlier.module.member.member.dto.MemberInputDto;
 import com.zerobase.foodlier.module.member.member.dto.MemberRegisterDto;
 import com.zerobase.foodlier.module.member.member.local.dto.CoordinateResponseDto;
@@ -13,11 +12,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import javax.transaction.Transactional;
+import java.util.Objects;
 
 @Component
 @Transactional
 @RequiredArgsConstructor
 public class MemberRegisterFacade {
+
+    private static final String NOT_PROFILE_IMAGE = null;
 
     private final EmailVerificationService emailVerificationService;
     private final MemberService memberService;
@@ -38,9 +40,9 @@ public class MemberRegisterFacade {
         CoordinateResponseDto coordinateResponseDto = localService.getCoordinate(
                 memberInputDto.getRoadAddress()
         );
-        String profileUrl = memberInputDto.getProfileImage() != null ?
+        String profileUrl = !Objects.isNull(memberInputDto.getProfileImage()) ?
                 s3Service.getImageUrl(memberInputDto.getProfileImage()) :
-                ProfileUrlConstants.PROFILE_DEFAULT_URL;
+                NOT_PROFILE_IMAGE;
 
         memberService.register(
                 MemberRegisterDto.from(

--- a/src/main/java/com/zerobase/foodlier/module/member/member/domain/model/Member.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/member/domain/model/Member.java
@@ -31,7 +31,6 @@ public class Member extends Audit {
     private String password;
     @Column(unique = true, nullable = false)
     private String phoneNumber;
-    @Column(nullable = false)
     private String profileUrl;
     @Embedded
     private Address address;

--- a/src/test/java/com/zerobase/foodlier/global/member/regiser/facade/MemberRegisterFacadeTest.java
+++ b/src/test/java/com/zerobase/foodlier/global/member/regiser/facade/MemberRegisterFacadeTest.java
@@ -18,9 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
-import static com.zerobase.foodlier.module.member.member.constants.ProfileUrlConstants.PROFILE_DEFAULT_URL;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
@@ -129,7 +127,7 @@ class MemberRegisterFacadeTest {
 
         assertAll(
                 () -> assertEquals(memberInputDto.getNickname(), memberRegisterDto.getNickname()),
-                () -> assertEquals(PROFILE_DEFAULT_URL, memberRegisterDto.getProfileUrl()),
+                () -> assertNull(memberRegisterDto.getProfileUrl()),
                 () -> assertEquals(memberInputDto.getEmail(), memberRegisterDto.getEmail()),
                 () -> assertEquals(memberInputDto.getPassword(), memberRegisterDto.getPassword()),
                 () -> assertEquals(memberInputDto.getPhoneNumber(), memberRegisterDto.getPhoneNumber()),


### PR DESCRIPTION
## Summary
- 도메인 회원가입 이미지 처리 방식 수정

## Describe your changes
- 이미지가 없을 경우, 이미지URL에 NULL값을 할당하도록 변경함.

## 데이터 변경 사항
- profileUrl에 nullable=false를 제거함

(DB 수정 SQL문)
```MYSQL
ALTER TABLE foodlier.member 
CHANGE COLUMN profile_url profile_url VARCHAR(255) NULL ;
```

## Issue number and link
#210 
