### PR TITLE
BE - 꿀조합 검색 필터 기능

### DIFF
--- a/src/main/java/com/zerobase/foodlier/global/recipe/controller/RecipeController.java
+++ b/src/main/java/com/zerobase/foodlier/global/recipe/controller/RecipeController.java
@@ -2,15 +2,13 @@ package com.zerobase.foodlier.global.recipe.controller;
 
 import com.zerobase.foodlier.common.response.ListResponse;
 import com.zerobase.foodlier.common.security.provider.dto.MemberAuthDto;
-import com.zerobase.foodlier.module.heart.service.HeartService;
-import com.zerobase.foodlier.module.recipe.dto.recipe.RecipeImageResponse;
 import com.zerobase.foodlier.global.recipe.facade.RecipeFacade;
-import com.zerobase.foodlier.module.recipe.domain.model.Recipe;
-import com.zerobase.foodlier.module.recipe.dto.recipe.RecipeDtoRequest;
-import com.zerobase.foodlier.module.recipe.dto.recipe.RecipeDtoResponse;
-import com.zerobase.foodlier.module.recipe.dto.recipe.RecipeListDto;
+import com.zerobase.foodlier.module.heart.service.HeartService;
+import com.zerobase.foodlier.module.recipe.dto.recipe.*;
 import com.zerobase.foodlier.module.recipe.service.recipe.RecipeService;
 import com.zerobase.foodlier.module.recipe.type.OrderType;
+import com.zerobase.foodlier.module.recipe.type.SearchType;
+import com.zerobase.foodlier.module.recipe.type.SortType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
@@ -80,12 +78,36 @@ public class RecipeController {
         return ResponseEntity.ok("레시피 접근 가능합니다.");
     }
 
-    @GetMapping("/{pageIdx}/{pageSize}")
-    public ResponseEntity<ListResponse<Recipe>> getRecipeListByTitle(@AuthenticationPrincipal MemberAuthDto memberAuthDto,
+    @GetMapping("search/{searchType}/{pageIdx}/{pageSize}")
+    public ResponseEntity<ListResponse<RecipeCardDto>> getRecipeList(@AuthenticationPrincipal MemberAuthDto memberAuthDto,
+                                                                     @PathVariable SearchType searchType,
                                                                      @PathVariable int pageIdx,
                                                                      @PathVariable int pageSize,
-                                                                     @RequestParam String recipeTitle) {
-        return ResponseEntity.ok(recipeService.getRecipeByTitle(recipeTitle, PageRequest.of(pageIdx, pageSize)));
+                                                                     @RequestParam String searchText) {
+        return ResponseEntity.ok(recipeService.getRecipeList(RecipeSearchRequest.builder()
+                .searchType(searchType)
+                .searchText(searchText)
+                .memberId(memberAuthDto.getId())
+                .pageable(PageRequest.of(pageIdx, pageSize))
+                .build())
+        );
+    }
+
+    @GetMapping("search/{searchType}/{sortType}/{pageIdx}/{pageSize}")
+    public ResponseEntity<ListResponse<RecipeCardDto>> getFilteredRecipeList(@AuthenticationPrincipal MemberAuthDto memberAuthDto,
+                                                                             @PathVariable SearchType searchType,
+                                                                             @PathVariable int pageIdx,
+                                                                             @PathVariable int pageSize,
+                                                                             @PathVariable SortType sortType,
+                                                                             @RequestParam String searchText) {
+        return ResponseEntity.ok(recipeService.getRecipeList(RecipeSearchRequest.builder()
+                .searchType(searchType)
+                .searchText(searchText)
+                .memberId(memberAuthDto.getId())
+                .pageable(PageRequest.of(pageIdx, pageSize))
+                .sortType(sortType)
+                .build())
+        );
     }
 
     @PostMapping("/heart/{recipeId}")
@@ -107,7 +129,7 @@ public class RecipeController {
     }
 
     @GetMapping("/main")
-    public ResponseEntity<List<RecipeListDto>> getMainPageRecipeList(
+    public ResponseEntity<List<RecipeCardDto>> getMainPageRecipeList(
             @AuthenticationPrincipal MemberAuthDto memberAuthDto
     ) {
         return ResponseEntity.ok(recipeService.
@@ -115,7 +137,7 @@ public class RecipeController {
     }
 
     @GetMapping("/default/{pageIdx}/{pageSize}")
-    public ResponseEntity<ListResponse<RecipeListDto>> getRecipePageRecipeList(
+    public ResponseEntity<ListResponse<RecipeCardDto>> getRecipePageRecipeList(
             @AuthenticationPrincipal MemberAuthDto memberAuthDto,
             @PathVariable int pageIdx,
             @PathVariable int pageSize,
@@ -127,7 +149,7 @@ public class RecipeController {
     }
 
     @GetMapping("/recommended")
-    public ResponseEntity<List<RecipeListDto>> getRecommendedRecipeList(
+    public ResponseEntity<List<RecipeCardDto>> getRecommendedRecipeList(
             @AuthenticationPrincipal MemberAuthDto memberAuthDto
     ) {
         return ResponseEntity.ok(recipeService.recommendedRecipe(memberAuthDto));

--- a/src/main/java/com/zerobase/foodlier/module/recipe/domain/document/RecipeDocument.java
+++ b/src/main/java/com/zerobase/foodlier/module/recipe/domain/document/RecipeDocument.java
@@ -1,15 +1,15 @@
 package com.zerobase.foodlier.module.recipe.domain.document;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.elasticsearch.annotations.Document;
-import org.springframework.data.elasticsearch.annotations.Mapping;
-import org.springframework.data.elasticsearch.annotations.Setting;
+import org.springframework.data.elasticsearch.annotations.*;
+import org.springframework.data.jpa.convert.threeten.Jsr310JpaConverters;
 
 import javax.persistence.Id;
-import java.util.List;
+import java.time.LocalDateTime;
 
 
 @Getter
@@ -20,20 +20,24 @@ import java.util.List;
 @Mapping(mappingPath = "/elasticsearch/recipe-mapping.json")
 @Setting(settingPath = "/elasticsearch/recipe-settings.json")
 public class RecipeDocument {
-
+    private static final int MIN_COMMENT = 0;
+    private static final String DATE_FORMAT = "uuuu-MM-dd'T'HH:mm:ss.SSS";
     @Id
     private Long id;
     private String title;
-    private List<String> ingredients;
+    private String ingredients;
     private String writer;
+    private long memberId;
     private long numberOfHeart;
     private long numberOfComment;
+    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second, pattern = DATE_FORMAT)
+    private LocalDateTime createAt;
 
     public void updateTitle(String title) {
         this.title = title;
     }
 
-    public void updateIngredients(List<String> ingredients) {
+    public void updateIngredients(String ingredients) {
         this.ingredients = ingredients;
     }
 
@@ -48,7 +52,8 @@ public class RecipeDocument {
     public void plusNumberOfComment() {
         this.numberOfComment++;
     }
+
     public void minusNumberOfComment() {
-        this.numberOfComment--;
+        this.numberOfComment = Math.max(MIN_COMMENT, --this.numberOfComment);
     }
 }

--- a/src/main/java/com/zerobase/foodlier/module/recipe/dto/recipe/RecipeCardDto.java
+++ b/src/main/java/com/zerobase/foodlier/module/recipe/dto/recipe/RecipeCardDto.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class RecipeListDto {
+public class RecipeCardDto {
     private String title;
     private String mainImageUrl;
     private String content;

--- a/src/main/java/com/zerobase/foodlier/module/recipe/dto/recipe/RecipeCardDto.java
+++ b/src/main/java/com/zerobase/foodlier/module/recipe/dto/recipe/RecipeCardDto.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class RecipeListDto {
+public class RecipeCardDto {
     private Long id;
     private String nickName;
     private String title;

--- a/src/main/java/com/zerobase/foodlier/module/recipe/dto/recipe/RecipeSearchRequest.java
+++ b/src/main/java/com/zerobase/foodlier/module/recipe/dto/recipe/RecipeSearchRequest.java
@@ -1,0 +1,31 @@
+package com.zerobase.foodlier.module.recipe.dto.recipe;
+
+import com.zerobase.foodlier.module.recipe.type.SearchType;
+import com.zerobase.foodlier.module.recipe.type.SortType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RecipeSearchRequest {
+    private Long memberId;
+    private SearchType searchType;
+    private Pageable pageable;
+    private String searchText;
+    @Builder.Default
+    private SortType sortType = SortType.CREATE_AT;
+
+
+    public Pageable getPageable(){
+        return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
+                Sort.by(Sort.Order.desc(this.sortType.getDocumentKey())));
+    }
+
+}

--- a/src/main/java/com/zerobase/foodlier/module/recipe/exception/recipe/RecipeErrorCode.java
+++ b/src/main/java/com/zerobase/foodlier/module/recipe/exception/recipe/RecipeErrorCode.java
@@ -13,6 +13,8 @@ public enum RecipeErrorCode {
     DELETED_RECIPE("삭제된 레시피입니다."),
     QUOTATION_CANNOT_BE_TAGGED("견적서는 태그할 수 없습니다."),
     ORDER_TYPE_NOT_FOUND("정의되지 않은 정렬타입입니다."),
+    SEARCH_TYPE_NOT_FOUND("정의되지 않은 검색 타입입니다."),
+    SORT_TYPE_NOT_FOUND("정의되지 않은 레시피 검색 정렬 타입입니다."),
     ;
 
     private final String description;

--- a/src/main/java/com/zerobase/foodlier/module/recipe/repository/RecipeSearchRepository.java
+++ b/src/main/java/com/zerobase/foodlier/module/recipe/repository/RecipeSearchRepository.java
@@ -7,7 +7,14 @@ import org.springframework.data.elasticsearch.annotations.Query;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
 public interface RecipeSearchRepository extends ElasticsearchRepository<RecipeDocument, Long> {
+
     @Query("{\"bool\": {\"must\": [{\"match_phrase_prefix\": {\"title.kor\": \"?0\"}}]}}")
     Page<RecipeDocument> findByTitle(String title, Pageable pageable);
+
+    @Query("{\"bool\": {\"must\": [{\"match\": {\"writer\": \"?0\"}}]}}")
+    Page<RecipeDocument> findByWriter(String writer, Pageable pageable);
+
+    @Query("{\"bool\": {\"must\": [{\"match\": {\"ingredients\": \"?0\"}}]}}")
+    Page<RecipeDocument> findByIngredients(String ingredients, Pageable pageable);
 
 }

--- a/src/main/java/com/zerobase/foodlier/module/recipe/service/recipe/RecipeService.java
+++ b/src/main/java/com/zerobase/foodlier/module/recipe/service/recipe/RecipeService.java
@@ -4,11 +4,7 @@ import com.zerobase.foodlier.common.response.ListResponse;
 import com.zerobase.foodlier.common.security.provider.dto.MemberAuthDto;
 import com.zerobase.foodlier.module.member.member.domain.model.Member;
 import com.zerobase.foodlier.module.recipe.domain.model.Recipe;
-import com.zerobase.foodlier.module.recipe.dto.recipe.ImageUrlDto;
-import com.zerobase.foodlier.module.recipe.dto.recipe.RecipeDtoRequest;
-import com.zerobase.foodlier.module.recipe.dto.recipe.RecipeDtoResponse;
-import com.zerobase.foodlier.module.recipe.dto.recipe.RecipeDtoTopResponse;
-import com.zerobase.foodlier.module.recipe.dto.recipe.RecipeListDto;
+import com.zerobase.foodlier.module.recipe.dto.recipe.*;
 import com.zerobase.foodlier.module.recipe.type.OrderType;
 import org.springframework.data.domain.Pageable;
 
@@ -25,14 +21,14 @@ public interface RecipeService {
 
     void deleteRecipe(Long id);
 
-    ListResponse<Recipe> getRecipeByTitle(String recipeTitle, Pageable pageable);
-
     ImageUrlDto getBeforeImageUrl(Long id);
+
     ListResponse<RecipeDtoTopResponse> getRecipeForHeart(Long memberId,
                                                          Pageable pageable);
+
     ListResponse<RecipeDtoTopResponse> getRecipeListByMemberId(Long memberId,
-                                                       Long targetMemberId,
-                                                       Pageable pageable);
+                                                               Long targetMemberId,
+                                                               Pageable pageable);
 
     void plusReviewStar(Long recipeId, int star);
 
@@ -44,11 +40,12 @@ public interface RecipeService {
 
     void minusCommentCount(Long recipeId);
 
-    List<RecipeListDto> getMainPageRecipeList(MemberAuthDto memberAuthDto);
+    List<RecipeCardDto> getMainPageRecipeList(MemberAuthDto memberAuthDto);
 
-    ListResponse<RecipeListDto> getRecipePageRecipeList(MemberAuthDto memberAuthDto,
+    ListResponse<RecipeCardDto> getRecipePageRecipeList(MemberAuthDto memberAuthDto,
                                                         Pageable pageable,
                                                         OrderType orderType);
 
-    List<RecipeListDto> recommendedRecipe(MemberAuthDto memberAuthDto);
+    List<RecipeCardDto> recommendedRecipe(MemberAuthDto memberAuthDto);
+    ListResponse<RecipeCardDto> getRecipeList(RecipeSearchRequest recipeSearchRequest);
 }

--- a/src/main/java/com/zerobase/foodlier/module/recipe/service/recipe/RecipeService.java
+++ b/src/main/java/com/zerobase/foodlier/module/recipe/service/recipe/RecipeService.java
@@ -4,10 +4,7 @@ import com.zerobase.foodlier.common.response.ListResponse;
 import com.zerobase.foodlier.common.security.provider.dto.MemberAuthDto;
 import com.zerobase.foodlier.module.member.member.domain.model.Member;
 import com.zerobase.foodlier.module.recipe.domain.model.Recipe;
-import com.zerobase.foodlier.module.recipe.dto.recipe.ImageUrlDto;
-import com.zerobase.foodlier.module.recipe.dto.recipe.RecipeDtoRequest;
-import com.zerobase.foodlier.module.recipe.dto.recipe.RecipeDtoResponse;
-import com.zerobase.foodlier.module.recipe.dto.recipe.RecipeListDto;
+import com.zerobase.foodlier.module.recipe.dto.recipe.*;
 import com.zerobase.foodlier.module.recipe.type.OrderType;
 import org.springframework.data.domain.Pageable;
 
@@ -24,8 +21,6 @@ public interface RecipeService {
 
     void deleteRecipe(Long id);
 
-    ListResponse<Recipe> getRecipeByTitle(String recipeTitle, Pageable pageable);
-
     ImageUrlDto getBeforeImageUrl(Long id);
 
     void plusReviewStar(Long recipeId, int star);
@@ -38,11 +33,12 @@ public interface RecipeService {
 
     void minusCommentCount(Long recipeId);
 
-    List<RecipeListDto> getMainPageRecipeList(MemberAuthDto memberAuthDto);
+    List<RecipeCardDto> getMainPageRecipeList(MemberAuthDto memberAuthDto);
 
-    ListResponse<RecipeListDto> getRecipePageRecipeList(MemberAuthDto memberAuthDto,
+    ListResponse<RecipeCardDto> getRecipePageRecipeList(MemberAuthDto memberAuthDto,
                                                         Pageable pageable,
                                                         OrderType orderType);
 
-    List<RecipeListDto> recommendedRecipe(MemberAuthDto memberAuthDto);
+    ListResponse<RecipeCardDto> getRecipeList(RecipeSearchRequest recipeSearchRequest);
+    List<RecipeCardDto> recommendedRecipe(MemberAuthDto memberAuthDto);
 }

--- a/src/main/java/com/zerobase/foodlier/module/recipe/service/recipe/RecipeServiceImpl.java
+++ b/src/main/java/com/zerobase/foodlier/module/recipe/service/recipe/RecipeServiceImpl.java
@@ -19,6 +19,7 @@ import com.zerobase.foodlier.module.recipe.exception.recipe.RecipeException;
 import com.zerobase.foodlier.module.recipe.repository.RecipeRepository;
 import com.zerobase.foodlier.module.recipe.repository.RecipeSearchRepository;
 import com.zerobase.foodlier.module.recipe.type.OrderType;
+import com.zerobase.foodlier.module.recipe.type.SortType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -155,6 +156,10 @@ public class RecipeServiceImpl implements RecipeService {
     @Transactional(readOnly = true)
     public ListResponse<RecipeCardDto> getRecipeList(RecipeSearchRequest recipeSearchRequest) {
         Page<RecipeDocument> findingResult;
+
+        if(!SortType.existsSortType(recipeSearchRequest.getSortType())){
+            throw new RecipeException(SORT_TYPE_NOT_FOUND);
+        }
 
         switch (recipeSearchRequest.getSearchType()) {
 

--- a/src/main/java/com/zerobase/foodlier/module/recipe/type/SearchType.java
+++ b/src/main/java/com/zerobase/foodlier/module/recipe/type/SearchType.java
@@ -1,0 +1,9 @@
+package com.zerobase.foodlier.module.recipe.type;
+
+public enum SearchType {
+
+    TITLE,
+    WRITER,
+    INGREDIENTS
+
+}

--- a/src/main/java/com/zerobase/foodlier/module/recipe/type/SortType.java
+++ b/src/main/java/com/zerobase/foodlier/module/recipe/type/SortType.java
@@ -1,0 +1,25 @@
+package com.zerobase.foodlier.module.recipe.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+
+@Getter
+@AllArgsConstructor
+public enum SortType {
+
+    HEART("numberOfHeart"),
+    COMMENT("numberOfComment"),
+    CREATE_AT("createAt");
+
+    private final String documentKey;
+
+    public static boolean existsSortType(SortType sortType){
+        return Arrays.stream(SortType.values())
+                .anyMatch(type -> type==sortType);
+
+    }
+
+}

--- a/src/main/resources/elasticsearch/recipe-mapping.json
+++ b/src/main/resources/elasticsearch/recipe-mapping.json
@@ -2,9 +2,11 @@
   "properties" : {
     "id" : {"type" : "long"},
     "title" : {"type" : "text", "fields": {"kor":  {"type":  "text", "analyzer": "korean"}}},
-    "chefName" : {"type" : "text", "fields": {"kor":  {"type":  "text", "analyzer": "korean"}}},
     "ingredients" :{"type": "text", "fields": {"kor": {"type": "text", "analyzer":  "korean"}}},
+    "writer" : {"type" : "text", "fields": {"kor":  {"type":  "text", "analyzer": "korean"}}},
+    "memberId": {"type" : "long"},
     "numberOfHeart" : {"type" : "long"},
-    "numberOfComment": {"type": "long"}
+    "numberOfComment": {"type": "long"},
+    "createdAt": {"type": "date", "format": "yyyy-MM-dd HH:mm:ss"}
   }
 }


### PR DESCRIPTION
## Summary

레시피 검색 필터 구현

## Describe your changes

### 제목 검색
- 레시피 제목으로 검색하는 기능 구현
- 유사한 제목까지 검색 가능
- 레시피 제목에 검색어가 포함된다면 유사한 제목으로 간주되어 검색

### 작성자 검색
- 레시피 작성자 닉네임으로 검색
- 닉네임은 정확하게 일치해야 검색 결과를 반환

### 재료 검색
- 레시피에 사용된 재료를 이용하여 검색
- 검색 창에 입력된 레시피 재료들을 띄어쓰기를 사이사이 추가하여 하나의 문자열로 변환 후 검색
- 재료가 여러 개인 경우 and 조건으로 검색 수행

## Issue number and link
#178
