### PR TITLE
BE - 도메인 회원가입시 이메일 인증 코드 형식 변경

### DIFF
--- a/src/main/java/com/zerobase/foodlier/global/member/mail/facade/EmailVerificationFacade.java
+++ b/src/main/java/com/zerobase/foodlier/global/member/mail/facade/EmailVerificationFacade.java
@@ -22,7 +22,7 @@ public class EmailVerificationFacade {
 
     public void sendMailAndCreateVerification(String email, LocalDateTime nowTime) {
         String verificationCode = randomCodeService
-                .createRandomCode();
+                .createIntegerRandomCode();
 
         emailVerificationService.createVerification(email, verificationCode,
                 nowTime);

--- a/src/main/java/com/zerobase/foodlier/module/member/member/mail/constants/GenerateCodeConstants.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/member/mail/constants/GenerateCodeConstants.java
@@ -8,4 +8,7 @@ public final class GenerateCodeConstants {
     public static final boolean USE_NUMBER = true;
     public static final boolean USE_LETTER = true;
 
+    public static final int INTEGER_CODE_RANGE = 1000000;
+    public static final String INTEGER_CODE_FORMAT = "%06d";
+
 }

--- a/src/main/java/com/zerobase/foodlier/module/member/member/mail/service/RandomCodeService.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/member/mail/service/RandomCodeService.java
@@ -2,4 +2,5 @@ package com.zerobase.foodlier.module.member.member.mail.service;
 
 public interface RandomCodeService {
     String createRandomCode();
+    String createIntegerRandomCode();
 }

--- a/src/main/java/com/zerobase/foodlier/module/member/member/mail/service/RandomCodeServiceImpl.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/member/mail/service/RandomCodeServiceImpl.java
@@ -17,7 +17,7 @@ public class RandomCodeServiceImpl implements RandomCodeService {
     /**
      *  작성자 : 전현서
      *  작성일 : 2023-10-13
-     *  정수 6자리로 된,
+     *  정수 6자리로 된, 랜덤 코드를 발급함.
      */
     @Override
     public String createIntegerRandomCode(){

--- a/src/main/java/com/zerobase/foodlier/module/member/member/mail/service/RandomCodeServiceImpl.java
+++ b/src/main/java/com/zerobase/foodlier/module/member/member/mail/service/RandomCodeServiceImpl.java
@@ -3,6 +3,8 @@ package com.zerobase.foodlier.module.member.member.mail.service;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.stereotype.Service;
 
+import java.util.Random;
+
 import static com.zerobase.foodlier.module.member.member.mail.constants.GenerateCodeConstants.*;
 
 @Service
@@ -10,5 +12,15 @@ public class RandomCodeServiceImpl implements RandomCodeService {
     @Override
     public String createRandomCode() {
         return RandomStringUtils.random(CODE_LENGTH, USE_LETTER, USE_NUMBER);
+    }
+
+    /**
+     *  작성자 : 전현서
+     *  작성일 : 2023-10-13
+     *  정수 6자리로 된,
+     */
+    @Override
+    public String createIntegerRandomCode(){
+        return String.format(INTEGER_CODE_FORMAT, new Random().nextInt(INTEGER_CODE_RANGE));
     }
 }

--- a/src/test/java/com/zerobase/foodlier/global/member/mail/facade/EmailVerificationFacadeTest.java
+++ b/src/test/java/com/zerobase/foodlier/global/member/mail/facade/EmailVerificationFacadeTest.java
@@ -38,11 +38,11 @@ class EmailVerificationFacadeTest {
 
         //given
         String email = "test178295031875@test.com";
-        String verificationCode = "LzOXCMpEUo";
+        String verificationCode = "751432";
         LocalDateTime nowTime = LocalDateTime.of(2023, 9, 25, 9, 0, 0);
 
 
-        given(randomCodeService.createRandomCode())
+        given(randomCodeService.createIntegerRandomCode())
                 .willReturn(verificationCode);
 
         //when

--- a/src/test/java/com/zerobase/foodlier/module/member/member/mail/service/RandomCodeServiceImplTest.java
+++ b/src/test/java/com/zerobase/foodlier/module/member/member/mail/service/RandomCodeServiceImplTest.java
@@ -17,4 +17,14 @@ class RandomCodeServiceImplTest {
         );
     }
 
+    @Test
+    void success_createIntegerRandomCode(){
+        String verificationCode = new RandomCodeServiceImpl().createIntegerRandomCode();
+
+        assertAll(
+                () -> assertEquals(6, verificationCode.length()),
+                () -> assertTrue(verificationCode.matches(".*[0-9].*"))
+        );
+    }
+
 }


### PR DESCRIPTION
## Summary
- 회원가입시 이메일 인증 코드 형식 변경

## Describe your changes
- 회원가입시 이메일 인증 코드 형식을 기존 영숫자 혼합에서, 숫자만 6자리 형태로 변환함.
- 이에 연관된 테스트 코드 추가 및 수정

## Issue number and link
#228 