### PR TITLE
BE - 배치처리 사용으로 인한 채팅, 채팅방 비즈니스 로직 수정

### DIFF
--- a/src/main/java/com/zerobase/foodlier/module/dm/room/domain/model/DmRoom.java
+++ b/src/main/java/com/zerobase/foodlier/module/dm/room/domain/model/DmRoom.java
@@ -37,4 +37,11 @@ public class DmRoom extends Audit {
     @Embedded
     private Suggestion suggestion;
 
+    public void updateMemberExit() {
+        this.isMemberExit = true;
+    }
+
+    public void updateChefExit() {
+        this.isChefExit = true;
+    }
 }

--- a/src/main/java/com/zerobase/foodlier/module/dm/room/service/DmRoomServiceImpl.java
+++ b/src/main/java/com/zerobase/foodlier/module/dm/room/service/DmRoomServiceImpl.java
@@ -1,7 +1,6 @@
 package com.zerobase.foodlier.module.dm.room.service;
 
 import com.zerobase.foodlier.common.response.ListResponse;
-import com.zerobase.foodlier.module.dm.dm.domain.model.Dm;
 import com.zerobase.foodlier.module.dm.dm.repository.DmRepository;
 import com.zerobase.foodlier.module.dm.room.domain.model.DmRoom;
 import com.zerobase.foodlier.module.dm.room.domain.vo.Suggestion;
@@ -17,7 +16,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
-import java.util.List;
 
 import static com.zerobase.foodlier.module.dm.room.exception.DmRoomErrorCode.DM_ROOM_NOT_FOUND;
 
@@ -72,22 +70,16 @@ public class DmRoomServiceImpl implements DmRoomService {
         DmRoom dmRoom = dmRoomRepository.findById(roomId)
                 .orElseThrow(() -> new DmRoomException(DM_ROOM_NOT_FOUND));
         if (id.equals(dmRoom.getRequest().getMember().getId())) {
-            dmRoom.setMemberExit(true);
+            dmRoom.updateMemberExit();
         } else {
-            dmRoom.setChefExit(true);
+            dmRoom.updateChefExit();
         }
 
         if (dmRoom.isMemberExit() && dmRoom.isChefExit()) {
-            List<Dm> dmList = dmRepository.findByDmroom(dmRoom);
-            dmRepository.deleteAll(dmList);
-
             Request request = dmRoom.getRequest();
-            request.setDmRoom(null);
+            request.exitDmRoom();
             requestRepository.save(request);
-
-            dmRoomRepository.delete(dmRoom);
-        } else {
-            dmRoomRepository.save(dmRoom);
         }
+        dmRoomRepository.save(dmRoom);
     }
 }

--- a/src/main/java/com/zerobase/foodlier/module/request/domain/model/Request.java
+++ b/src/main/java/com/zerobase/foodlier/module/request/domain/model/Request.java
@@ -56,4 +56,8 @@ public class Request extends Audit {
     @ManyToOne
     @JoinColumn(name = "recipe_id")
     private Recipe recipe;
+
+    public void exitDmRoom() {
+        this.dmRoom = null;
+    }
 }

--- a/src/test/java/com/zerobase/foodlier/module/dm/room/service/DmRoomServiceImplTest.java
+++ b/src/test/java/com/zerobase/foodlier/module/dm/room/service/DmRoomServiceImplTest.java
@@ -136,23 +136,16 @@ public class DmRoomServiceImplTest {
                 .isMemberExit(false)
                 .isChefExit(true)
                 .build();
-        List<Dm> dmList = new ArrayList<>(List.of(Dm.builder()
-                .text("채팅")
-                .build()));
 
         given(dmRoomRepository.findById(roomId))
                 .willReturn(Optional.ofNullable(dmRoom));
-        given(dmRepository.findByDmroom(dmRoom))
-                .willReturn(dmList);
 
         //when
         dmRoomService.exitDmRoom(id, roomId);
 
         //then
-        verify(dmRepository, times(1)).deleteAll(dmList);
         verify(requestRepository, times(1)).save(dmRoom.getRequest());
-        verify(dmRoomRepository, times(1)).delete(dmRoom);
-        verify(dmRoomRepository, times(1)).delete(dmRoom);
+        verify(dmRoomRepository, times(1)).save(dmRoom);
     }
 
     @Test


### PR DESCRIPTION
## Summary
배치처리 사용으로 채팅 관련 로직 수정

## Describe your changes
배치처리 사용으로 비즈니스 로직에서 기존의 채팅방 나가기 시 채팅방 삭제, 채팅 삭제 기능을 삭제하였습니다.
채팅방을 나가면 나가기 여부만 true로 바뀌며, 이후 배치처리로 참가자 두 명 모두 나간 상태에서만 채팅과 채팅방을 삭제하는 기능이 구현됩니다.

로직 수정으로 테스트코드 또한 일부 수정되었습니다.

## Issue number and link
#252 