### PR TITLE
BE - !hotfix 미열람 알림 갯수 조회 오작동 수정

### DIFF
--- a/src/main/java/com/zerobase/foodlier/module/notification/repository/notification/NotificationRepositoryCustomImpl.java
+++ b/src/main/java/com/zerobase/foodlier/module/notification/repository/notification/NotificationRepositoryCustomImpl.java
@@ -46,10 +46,10 @@ public class NotificationRepositoryCustomImpl implements NotificationRepositoryC
 
         return jpaQueryFactory.select(notification.count())
                 .from(notification)
-                .join(member)
-                .on(notification.member.id.eq(memberId))
-                .where(notification.isRead.eq(NOT_READ))
-                .fetchFirst();
+                .leftJoin(member)
+                .on(member.id.eq(memberId))
+                .where(notification.member.id.eq(memberId).and(notification.isRead.eq(NOT_READ)))
+                .fetchOne();
     }
 
     @Override


### PR DESCRIPTION
## Summary
### 미열람 알림 갯수 조회 오작동 수정
## Describe your changes
### 미열람 알림 갯수 조회 오작동 수정
- 미열람 알림 갯수를 조회하는 쿼리에서 잘못된 join 조건으로 인해 미열람 알림 갯수가 올바르지 않은 현상을 바로잡기 위해 join 조건을 올바르게 수정
## Issue number and link
#256 