### PR TITLE
BE - Recipe에 대한 SoftDelete 정의 및 RequestForm 및 Request에 대한 누락 응답 칼럼 추가

### DIFF
--- a/src/main/java/com/zerobase/foodlier/module/recipe/domain/model/Recipe.java
+++ b/src/main/java/com/zerobase/foodlier/module/recipe/domain/model/Recipe.java
@@ -19,6 +19,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -30,6 +32,8 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 @AllArgsConstructor
 @SuperBuilder
+@Where(clause = "is_deleted = false")
+@SQLDelete(sql = "UPDATE recipe SET is_deleted = true WHERE id = ?")
 public class Recipe extends Audit {
     private final static int ZERO = 0;
     @Id

--- a/src/main/java/com/zerobase/foodlier/module/request/dto/RequestDetailDto.java
+++ b/src/main/java/com/zerobase/foodlier/module/request/dto/RequestDetailDto.java
@@ -21,6 +21,7 @@ public class RequestDetailDto {
     private LocalDateTime expectedAt;
     private String address;
     private String addressDetail;
+    private Long recipeId;
     private String mainImageUrl;
     private String recipeTitle;
     private String recipeContent;

--- a/src/main/java/com/zerobase/foodlier/module/request/service/RequestService.java
+++ b/src/main/java/com/zerobase/foodlier/module/request/service/RequestService.java
@@ -68,7 +68,8 @@ public class RequestService {
                 .addressDetail(request.getMember().getAddress().getAddressDetail());
 
         if (!Objects.isNull(request.getRecipe())) {
-            builder.mainImageUrl(request.getRecipe().getMainImageUrl())
+            builder.recipeId(request.getRecipe().getId())
+                    .mainImageUrl(request.getRecipe().getMainImageUrl())
                     .recipeTitle(request.getRecipe().getSummary().getTitle())
                     .recipeContent(request.getRecipe().getSummary().getContent())
                     .heartCount(request.getRecipe().getHeartCount());

--- a/src/main/java/com/zerobase/foodlier/module/requestform/dto/RequestFormDetailDto.java
+++ b/src/main/java/com/zerobase/foodlier/module/requestform/dto/RequestFormDetailDto.java
@@ -25,6 +25,7 @@ public class RequestFormDetailDto {
     private String address;
     private String addressDetail;
     private String mainImageUrl;
+    private Long recipeId;
     private String recipeTitle;
     private String recipeContent;
     private int heartCount;

--- a/src/main/java/com/zerobase/foodlier/module/requestform/service/RequestFormService.java
+++ b/src/main/java/com/zerobase/foodlier/module/requestform/service/RequestFormService.java
@@ -113,7 +113,8 @@ public class RequestFormService {
                 .addressDetail(requestForm.getMember().getAddress().getAddressDetail());
 
         if (!Objects.isNull(requestForm.getRecipe())) {
-            builder.mainImageUrl(requestForm.getRecipe().getMainImageUrl())
+            builder.recipeId(requestForm.getRecipe().getId())
+                    .mainImageUrl(requestForm.getRecipe().getMainImageUrl())
                     .recipeTitle(requestForm.getRecipe().getSummary().getTitle())
                     .recipeContent(requestForm.getRecipe().getSummary().getContent())
                     .heartCount(requestForm.getRecipe().getHeartCount());

--- a/src/test/java/com/zerobase/foodlier/module/request/service/RequestServiceTest.java
+++ b/src/test/java/com/zerobase/foodlier/module/request/service/RequestServiceTest.java
@@ -165,6 +165,7 @@ class RequestServiceTest {
                     () -> assertEquals(requester.getAddress().getRoadAddress(), response.getAddress()),
                     () -> assertEquals(requester.getAddress().getAddressDetail(), response.getAddressDetail()),
                     () -> assertEquals(requester.getAddress().getAddressDetail(), response.getAddressDetail()),
+                    () -> assertEquals(recipe.getId(), response.getRecipeId()),
                     () -> assertEquals(recipe.getMainImageUrl(), response.getMainImageUrl()),
                     () -> assertEquals(recipe.getSummary().getTitle(), response.getRecipeTitle()),
                     () -> assertEquals(recipe.getSummary().getContent(), response.getRecipeContent()),

--- a/src/test/java/com/zerobase/foodlier/module/requestForm/service/RequestFormServiceTest.java
+++ b/src/test/java/com/zerobase/foodlier/module/requestForm/service/RequestFormServiceTest.java
@@ -383,6 +383,7 @@ class RequestFormServiceTest {
                 () -> assertEquals(requestForm.getMember().getAddress().getRoadAddress(), requestFormDetailDto.getAddress()),
                 () -> assertEquals(requestForm.getMember().getAddress().getAddressDetail(), requestFormDetailDto.getAddressDetail()),
                 () -> assertEquals(requestForm.getMember().getAddress().getAddressDetail(), requestFormDetailDto.getAddressDetail()),
+                () -> assertEquals(requestForm.getRecipe().getId(), requestFormDetailDto.getRecipeId()),
                 () -> assertEquals(requestForm.getRecipe().getMainImageUrl(), requestFormDetailDto.getMainImageUrl()),
                 () -> assertEquals(requestForm.getRecipe().getSummary().getTitle(), requestFormDetailDto.getRecipeTitle()),
                 () -> assertEquals(requestForm.getRecipe().getSummary().getContent(), requestFormDetailDto.getRecipeContent()),


### PR DESCRIPTION
## Summary
- Recipe에 대해 SoftDelete를 정의함
- RequestForm 및 Request 상세 조회시 누락된 칼럼 추가

## Describe your changes

### `@SQLDelete()`
- 해당 어노테이션은 JPA에서 Delete 메서드를 수행할 때, 동작할 쿼리를 지정합니다.
- 해당 부분에 Recipe의 isDeleted가 true로 변경되도록 작성하였습니다.

### `@Where()`
- 해당 어노테이션은 JPA에서 find를 수행할 때, 추가적으로 붙일 조건을 정의합니다.
- 해당 부분에, isDeleted가 false인 부분만 데이터를 가져오도록 설정하여, 삭제한 Recipe는 조회하지 않도록 합니다.

### RequestForm 및 Request에 대한 누락 칼럼 추가
- 각각 DetailDto에 RecipeId를 가져올 수 있게 해당 칼럼을 추가하였습니다.
- 이와 연관된 테스트 코드를 수정하였습니다.

## Issue number and link
#288 
