### PR TITLE
BE - !HOTFIX 공개 프로필 RecipeReview 조회 쿼리 수정

### DIFF
--- a/src/main/java/com/zerobase/foodlier/module/review/recipe/repository/RecipeReviewRepository.java
+++ b/src/main/java/com/zerobase/foodlier/module/review/recipe/repository/RecipeReviewRepository.java
@@ -3,8 +3,6 @@ package com.zerobase.foodlier.module.review.recipe.repository;
 import com.zerobase.foodlier.module.member.member.domain.model.Member;
 import com.zerobase.foodlier.module.recipe.domain.model.Recipe;
 import com.zerobase.foodlier.module.review.recipe.domain.model.RecipeReview;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -17,6 +15,5 @@ public interface RecipeReviewRepository extends JpaRepository<RecipeReview, Long
 
     Optional<RecipeReview> findByMemberAndRecipe(Member member, Recipe recipe);
 
-    Page<RecipeReview> findByMemberOrderByCreatedAtDesc(Member member, Pageable pageable);
 
 }

--- a/src/main/java/com/zerobase/foodlier/module/review/recipe/repository/RecipeReviewRepositoryCustom.java
+++ b/src/main/java/com/zerobase/foodlier/module/review/recipe/repository/RecipeReviewRepositoryCustom.java
@@ -6,4 +6,6 @@ import org.springframework.data.domain.Pageable;
 
 public interface RecipeReviewRepositoryCustom {
     Page<RecipeReview> findRecipe(Long recipeId, Long memberId, Pageable pageable);
+
+    Page<RecipeReview> findByRecipeReviewForRecipeWriter(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/zerobase/foodlier/module/review/recipe/repository/RecipeReviewRepositoryCustomImpl.java
+++ b/src/main/java/com/zerobase/foodlier/module/review/recipe/repository/RecipeReviewRepositoryCustomImpl.java
@@ -1,5 +1,7 @@
 package com.zerobase.foodlier.module.review.recipe.repository;
 
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringPath;
 import com.querydsl.core.types.dsl.Wildcard;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -18,6 +20,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class RecipeReviewRepositoryCustomImpl implements RecipeReviewRepositoryCustom {
     private final JPAQueryFactory queryFactory;
+    private final StringPath CREATED_AT_ORDER_BY = Expressions.stringPath("createdAt");
 
     @Override
     public Page<RecipeReview> findRecipe(Long recipeId, Long memberId, Pageable pageable) {
@@ -48,6 +51,7 @@ public class RecipeReviewRepositoryCustomImpl implements RecipeReviewRepositoryC
                                 .selectFrom(recipe)
                                 .where(recipe.member.id.eq(memberId))
                 ))
+                .orderBy(CREATED_AT_ORDER_BY.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();

--- a/src/main/java/com/zerobase/foodlier/module/review/recipe/service/RecipeReviewService.java
+++ b/src/main/java/com/zerobase/foodlier/module/review/recipe/service/RecipeReviewService.java
@@ -86,9 +86,8 @@ public class RecipeReviewService {
      */
     public ListResponse<RecipeReviewResponseDto> getRecipeReviewForProfile(Long memberId,
                                                                            Pageable pageable) {
-        Member member = getMember(memberId);
         return ListResponse.from(
-                recipeReviewRepository.findByMemberOrderByCreatedAtDesc(member, pageable),
+                recipeReviewRepository.findByRecipeReviewForRecipeWriter(memberId, pageable),
                 RecipeReviewResponseDto::from);
     }
 

--- a/src/test/java/com/zerobase/foodlier/module/review/recipe/service/RecipeReviewServiceTest.java
+++ b/src/test/java/com/zerobase/foodlier/module/review/recipe/service/RecipeReviewServiceTest.java
@@ -538,10 +538,7 @@ class RecipeReviewServiceTest {
                 .createdAt(LocalDateTime.now())
                 .build();
 
-        given(memberRepository.findById(anyLong()))
-                .willReturn(Optional.of(Member.builder().build()));
-
-        given(recipeReviewRepository.findByMemberOrderByCreatedAtDesc(any(), any()))
+        given(recipeReviewRepository.findByRecipeReviewForRecipeWriter(anyLong(), any()))
                 .willReturn(new PageImpl<>(List.of(recipeReview)));
 
         //when
@@ -563,22 +560,5 @@ class RecipeReviewServiceTest {
 
     }
 
-    @Test
-    @DisplayName("공개 프로필 꿀조합 후기 조회 실패 - 회원 X")
-    void fail_getRecipeReviewForProfile(){
-
-        //given
-        given(memberRepository.findById(anyLong()))
-                .willReturn(Optional.empty());
-
-        //when
-        MemberException exception = assertThrows(MemberException.class,
-                () -> recipeReviewService
-                        .getRecipeReviewForProfile(1L,
-                                PageRequest.of(0, 10)));
-
-        //then
-        assertEquals(MEMBER_NOT_FOUND, exception.getErrorCode());
-    }
 
 }


### PR DESCRIPTION
## Summary
- 공개프로필 RecipeReview 조회 쿼리 수정

## Describe your changes

### 문제점
```JAVA
Page<RecipeReview> findByMemberOrderByCreatedAtDesc(Member member, Pageable pageable);
```
- 기존에 쿼리 메소드로는 해당 멤버가 작성한 레시피 후기를 응답으로 반환하게 되어있음.
- 하지만, 원하는 응답은 해당 멤버가 작성한 레시피에 대한 후기에 대한 리뷰가 조회되어야 함.

### QueryDSL로 변경
- Join 연산이 들어가므로, QueryDSL로 변경하여 해결완료!

## Issue number and link
#301 
