### PR TITLE
BE - 알림 전송 객체 관련 에러 처리

### DIFF
--- a/src/main/java/com/zerobase/foodlier/module/notification/service/emitter/EmitterService.java
+++ b/src/main/java/com/zerobase/foodlier/module/notification/service/emitter/EmitterService.java
@@ -36,8 +36,8 @@ public class EmitterService {
                     .name(EVENT_NAME)
                     .data(data));
         } catch (IOException exception) {
-            emitter.complete();
             emitterRepository.deleteById(emitterId);
+            emitter.complete();
             throw new NotificationException(NotificationErrorCode.NO_SUCH_EMITTER);
         }
     }


### PR DESCRIPTION
## Summary
### 알림 전송 객체 관련 에러 처리

## Describe your changes

### 알림 전송 객체 관련 에러 처리
알림 전송 객체를 이용하여 알림 전송 시 문제가 발생했을 경우 알림 객체의
http 연결을 먼저 끊는 방식을 알림 전송 객체 저장소(concurrentHashMap)에서 삭제 이후 연결을 종료하는 방식으로 수정

## Issue number and link
#288