### PR TITLE
BE - 충전 내역 조회시 해당 충전 요청이 취소되었는지의 값 추가

### DIFF
--- a/src/main/java/com/zerobase/foodlier/module/history/charge/dto/PointChargeHistoryDto.java
+++ b/src/main/java/com/zerobase/foodlier/module/history/charge/dto/PointChargeHistoryDto.java
@@ -2,6 +2,7 @@ package com.zerobase.foodlier.module.history.charge.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.zerobase.foodlier.module.history.charge.domain.model.PointChargeHistory;
+import com.zerobase.foodlier.module.history.type.TransactionType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,6 +20,7 @@ public class PointChargeHistoryDto {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime chargeAt;
     private String description;
+    private boolean isCanceled;
 
     public static PointChargeHistoryDto from(PointChargeHistory pointChargeHistory) {
         return PointChargeHistoryDto.builder()
@@ -26,6 +28,7 @@ public class PointChargeHistoryDto {
                 .chargePoint(pointChargeHistory.getChargePoint())
                 .chargeAt(pointChargeHistory.getCreatedAt())
                 .description(pointChargeHistory.getTransactionType().getDescription())
+                .isCanceled(pointChargeHistory.getTransactionType().equals(TransactionType.CHARGE_CANCEL))
                 .build();
     }
 }


### PR DESCRIPTION
## Summary
- 충전 내역 조회 시 취소된 값인지 확인 하는 값 추가

## Describe your changes
- 도빈님이 요구하신 부분인데 환불한 건에대해서 취소되었는지의 값이 필요하시다고 하셔가지고 일단 수정하긴 했는데 옳바른 수정인지 헷갈려서 의견 남겨주시면 감사합니다!

## Issue number and link
#389