### PR TITLE
BE - 레시피 수정 시 단일 이미지 업로드를 위한 API 추가

### DIFF
--- a/src/main/java/com/zerobase/foodlier/global/recipe/controller/RecipeController.java
+++ b/src/main/java/com/zerobase/foodlier/global/recipe/controller/RecipeController.java
@@ -56,6 +56,12 @@ public class RecipeController {
                 mainImage, cookingOrderImageList, recipeId));
     }
 
+    @PostMapping("/image/single")
+    public ResponseEntity<SingleImageResponse> uploadSingleImage(
+            @Valid @ImageFile @RequestPart MultipartFile image) {
+        return ResponseEntity.ok(recipeFacade.uploadSingleImage(image));
+    }
+
     @PostMapping
     public ResponseEntity<String> createRecipe(@AuthenticationPrincipal MemberAuthDto memberAuthDto,
                                                @RequestBody @Valid RecipeDtoRequest recipeDto) {

--- a/src/main/java/com/zerobase/foodlier/global/recipe/facade/RecipeFacade.java
+++ b/src/main/java/com/zerobase/foodlier/global/recipe/facade/RecipeFacade.java
@@ -4,10 +4,7 @@ import com.zerobase.foodlier.common.s3.service.S3Service;
 import com.zerobase.foodlier.module.member.member.domain.model.Member;
 import com.zerobase.foodlier.module.member.member.service.MemberService;
 import com.zerobase.foodlier.module.recipe.domain.model.Recipe;
-import com.zerobase.foodlier.module.recipe.dto.recipe.ImageUrlDto;
-import com.zerobase.foodlier.module.recipe.dto.recipe.RecipeDetailDto;
-import com.zerobase.foodlier.module.recipe.dto.recipe.RecipeDtoRequest;
-import com.zerobase.foodlier.module.recipe.dto.recipe.RecipeImageResponse;
+import com.zerobase.foodlier.module.recipe.dto.recipe.*;
 import com.zerobase.foodlier.module.recipe.exception.recipe.RecipeException;
 import com.zerobase.foodlier.module.recipe.service.recipe.RecipeService;
 import lombok.RequiredArgsConstructor;
@@ -60,6 +57,15 @@ public class RecipeFacade {
                 .cookingOrderImageList(s3Service
                         .getImageUrlList(cookingOrderImageList))
                 .build();
+    }
+
+    /**
+     * 2023-11-10
+     * 황태원
+     * 단일 사진 업로드 시 s3에 등록 후 url을 return
+     */
+    public SingleImageResponse uploadSingleImage(MultipartFile image) {
+        return new SingleImageResponse(s3Service.getImageUrl(image));
     }
 
     /**

--- a/src/main/java/com/zerobase/foodlier/module/recipe/dto/recipe/SingleImageResponse.java
+++ b/src/main/java/com/zerobase/foodlier/module/recipe/dto/recipe/SingleImageResponse.java
@@ -1,0 +1,12 @@
+package com.zerobase.foodlier.module.recipe.dto.recipe;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SingleImageResponse {
+    private String image;
+}


### PR DESCRIPTION
## Summary
레시피 수정 시 단일 이미지 업로드를 위한 API 추가

## Describe your changes
레시피 수정 시 File과 URL이 공존하여 기존의 updateRecipeImage로는 사용이 어렵다고 판단
따라서 수정 시 사진 File 업로드 방법을 모든 이미지를 업로드 하는 방법에서 단일 이미지를 업로드하는 API를 호출하는 것으로 변경

추가된 API : 
```
/recipe/image/single
```
반환값 : 
```json
{
    "image": "업로드 후 반환되는 이미지URL" 
}
```

## Issue number and link
#394 