### PR TITLE
BE - 403 에러 해결을 위한 설정 변경

### DIFF
--- a/src/main/java/com/zerobase/foodlier/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/zerobase/foodlier/common/security/config/SecurityConfig.java
@@ -101,7 +101,7 @@ public class SecurityConfig {
                 "http://127.0.0.1:5173",
                 "http://127.0.0.1:8080",
                 "http://localhost:8080",
-                "https://zb-foodlier.vercel.app",
+                "https://zb-foodlier-iota.vercel.app/",
                 "http://ec2-15-165-55-217.ap-northeast-2.compute.amazonaws.com",
                 "http://ec2-13-209-238-113.ap-northeast-2.compute.amazonaws.com"
         ));


### PR DESCRIPTION
## Summary
403 에러 해결을 위한 spring security 설정 변경

## Describe your changes
AWS EC2에 ELB를 이용하여 https 적용 시 발생하는 403 에러를 해결하기 위해
vercel 주소 변경

## Issue number and link
